### PR TITLE
Fix up interface mismatch

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -296,7 +296,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
-    override fun pushIosOverridePresentationOptions(options: ReadableArray?, requestId: String?) {
+    override fun pushIosOverridePresentationOptions(requestId: String?, options: ReadableArray?) {
         // iOS only
     }
 
@@ -323,7 +323,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
-    override fun pushAndroidOverrideForegroundDisplay(shouldDisplay: Boolean, requestId: String?) {
+    override fun pushAndroidOverrideForegroundDisplay(requestId: String?, shouldDisplay: Boolean) {
         if (requestId == null) {
             return
         }
@@ -383,7 +383,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
-    override fun contactEditContactSubscriptionLists(
+    override fun contactEditSubscriptionLists(
             operations: ReadableArray?,
             promise: Promise
     ) {

--- a/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
+++ b/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
@@ -151,7 +151,7 @@ abstract class AirshipSpec internal constructor(context: ReactApplicationContext
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
-    abstract fun pushIosOverridePresentationOptions(options: ReadableArray?, requestId: String?)
+    abstract fun pushIosOverridePresentationOptions(requestId: String?, options: ReadableArray?)
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
@@ -170,7 +170,7 @@ abstract class AirshipSpec internal constructor(context: ReactApplicationContext
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
-    abstract fun pushAndroidOverrideForegroundDisplay(shouldDisplay: Boolean, requestId: String?)
+    abstract fun pushAndroidOverrideForegroundDisplay(requestId: String?, shouldDisplay: Boolean)
 
 
     @ReactMethod
@@ -205,7 +205,7 @@ abstract class AirshipSpec internal constructor(context: ReactApplicationContext
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
-    abstract fun contactEditContactSubscriptionLists(
+    abstract fun contactEditSubscriptionLists(
         operations: ReadableArray?,
         promise: Promise
     )

--- a/ios/RTNAirship.mm
+++ b/ios/RTNAirship.mm
@@ -361,8 +361,8 @@ RCT_REMAP_METHOD(contactEditAttributes,
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
 
-RCT_REMAP_METHOD(contactEditContactSubscriptionLists,
-                 contactEditContactSubscriptionLists:(NSArray *)operations
+RCT_REMAP_METHOD(contactEditSubscriptionLists,
+                 contactEditSubscriptionLists:(NSArray *)operations
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
@@ -655,7 +655,7 @@ RCT_EXPORT_METHOD(pushIosIsOverridePresentationOptionsEnabled:(BOOL)enabled) {
     AirshipReactNative.shared.overridePresentationOptionsEnabled = enabled;
 }
 
-RCT_EXPORT_METHOD(pushIosOverridePresentationOptions:(NSArray *)presentationOptions requestId:(NSString *)requestID) {
+RCT_EXPORT_METHOD(pushIosOverridePresentationOptions:(NSString *)requestID options:(NSArray *)presentationOptions) {
     [AirshipReactNative.shared presentationOptionOverridesResultWithRequestID:requestID presentationOptions:presentationOptions];
 }
 
@@ -663,7 +663,7 @@ RCT_EXPORT_METHOD(pushAndroidIsOverrideForegroundDisplayEnabled:(BOOL)enabled) {
     // Android only
 }
 
-RCT_EXPORT_METHOD(pushAndroidOverrideForegroundDisplay:(BOOL)display requestId:(NSString *)requestID) {
+RCT_EXPORT_METHOD(pushAndroidOverrideForegroundDisplay:(NSString *)requestID shouldDisplay:(BOOL)display) {
     // Android only
 }
 

--- a/src/AirshipPreferenceCenter.ts
+++ b/src/AirshipPreferenceCenter.ts
@@ -36,7 +36,7 @@ export class AirshipPreferenceCenter {
    */
   public setAutoLaunchDefaultPreferenceCenter(
     preferenceCenterId: string,
-    autoLaunch: Boolean
+    autoLaunch: boolean
   ): void {
     return this.module.preferenceCenterAutoLaunchDefaultPreferenceCenter(
       preferenceCenterId,

--- a/src/AirshipPush.ts
+++ b/src/AirshipPush.ts
@@ -114,14 +114,14 @@ export class AirshipPushIOS {
     if (Platform.OS === 'ios') {
       this.eventEmitter.addListener("com.airship.ios.override_presentation_options", (event) => {
         let payload = event["pushPayload"] as PushPayload
-        let requestId = event["requestId"] as String
+        let requestId = event["requestId"] as string
   
         if (this.presentationOverridesCallback) {
           this.presentationOverridesCallback(payload).then( (result) => {
-            module.pushIosOverridePresentationOptions(result, requestId);
+            module.pushIosOverridePresentationOptions(requestId, result);
           })
           .catch(() => {
-            module.pushIosOverridePresentationOptions(null, requestId);
+            module.pushIosOverridePresentationOptions(requestId, null);
           });
         }
       })
@@ -205,7 +205,7 @@ export class AirshipPushIOS {
 export class AirshipPushAndroid {
 
   private eventEmitter: NativeEventEmitter;
-  private foregroundDisplayPredicate?: (pushPayload: PushPayload) => Promise<Boolean>
+  private foregroundDisplayPredicate?: (pushPayload: PushPayload) => Promise<boolean>
 
   constructor(private readonly module: any) {
     this.eventEmitter = new NativeEventEmitter(module);
@@ -213,14 +213,14 @@ export class AirshipPushAndroid {
     if (Platform.OS === 'android') {
       this.eventEmitter.addListener("com.airship.android.override_foreground_display", (event) => {
         let payload = event["pushPayload"] as PushPayload
-        let requestId = event["requestId"] as String
+        let requestId = event["requestId"] as string
   
         if (this.foregroundDisplayPredicate) {
           this.foregroundDisplayPredicate(payload).then( (result) => {
-            module.pushAndroidOverrideForegroundDisplay(result, requestId);
+            module.pushAndroidOverrideForegroundDisplay(requestId, result);
           })
           .catch(() => {
-            module.pushAndroidOverrideForegroundDisplay(true, requestId);
+            module.pushAndroidOverrideForegroundDisplay(requestId, true);
           });
         }
       })

--- a/src/NativeRTNAirship.ts
+++ b/src/NativeRTNAirship.ts
@@ -41,13 +41,13 @@ export interface Spec extends TurboModule {
   pushIosSetBadgeNumber(badgeNumber: number): Promise<void>;
   pushIosGetBadgeNumber(): Promise<number>;
   pushIosIsOverridePresentationOptionsEnabled(enabled: boolean): void;
-  pushIosOverridePresentationOptions(options: string[], requestId: string): void;
+  pushIosOverridePresentationOptions(requestId: string, options?: string[]): void;
 
   // Push.android
   pushAndroidIsNotificationChannelEnabled(channel: string): Promise<boolean>;
   pushAndroidSetNotificationConfig(config: Object): void;
   pushAndroidIsOverrideForegroundDisplayEnabled(enabled: boolean): void;
-  pushAndroidOverrideForegroundDisplay(shouldDisplay: boolean, requestId: string): void;
+  pushAndroidOverrideForegroundDisplay(requestId: string, shouldDisplay: boolean): void;
 
   // Contact
   contactIdentify(namedUser: string): Promise<void>;
@@ -56,17 +56,17 @@ export interface Spec extends TurboModule {
   contactGetSubscriptionLists(): Promise<Object>;
   contactEditTagGroups(operations: Object[]): Promise<void>;
   contactEditAttributes(operations: Object[]): Promise<void>;
-  contactEditContactSubscriptionLists(operations: Object[]): Promise<void>;
+  contactEditSubscriptionLists(operations: Object[]): Promise<void>;
 
   // Analytics
-  analyticsTrackScreen(screen: string): Promise<void>;
+  analyticsTrackScreen(screen?: string): Promise<void>;
   analyticsAssociateIdentifier(key: string, identifier?: string): Promise<void>;
 
   // Action
   actionRun(name: string, value?: Object): Promise<Object | Error>;
 
   // Privacy Manager
-  privacyManagerSetEnabledFeatures(features: string[]): Promise<boolean>;
+  privacyManagerSetEnabledFeatures(features: string[]): Promise<void>;
   privacyManagerGetEnabledFeatures(): Promise<string[]>;
   privacyManagerEnableFeature(features: string[]): Promise<void>;
   privacyManagerDisableFeature(features: string[]): Promise<void>;
@@ -81,10 +81,10 @@ export interface Spec extends TurboModule {
   // Message Center
   messageCenterGetUnreadCount(): Promise<number>;
   messageCenterDismiss(): Promise<void>;
-  messageCenterDisplay(messageId?: string): Promise<boolean>;
+  messageCenterDisplay(messageId?: string): Promise<void>;
   messageCenterGetMessages(): Promise<Object[]>;
-  messageCenterDeleteMessage(messageId: string): Promise<boolean>;
-  messageCenterMarkMessageRead(messageId: string): Promise<boolean>;
+  messageCenterDeleteMessage(messageId: string): Promise<void>;
+  messageCenterMarkMessageRead(messageId: string): Promise<void>;
   messageCenterRefresh(): Promise<void>;
   messageCenterSetAutoLaunchDefaultMessageCenter(enabled: boolean): void;
 


### PR DESCRIPTION
Fixing type mismatches between the bindings. I went through and replaced `any` with `Spec` to see where it complained. I then reverted that change for now because the docs show to use `any`, but we should see if we can make this better going forward as its too easy to use a wrong method if we dont have type checks. 