### PR TITLE
fix: Import when using cocapods frameworks

### DIFF
--- a/ios/RTNAirship.mm
+++ b/ios/RTNAirship.mm
@@ -1,7 +1,12 @@
 /* Copyright Airship and Contributors */
 
 #import "RTNAirship.h"
+
+#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
+#import <react_native_airship/react_native_airship-Swift.h>
+#else
 #import "react_native_airship-Swift.h"
+#endif
 
 @implementation RTNAirship
 RCT_EXPORT_MODULE()

--- a/ios/RTNAirshipBootloader.m
+++ b/ios/RTNAirshipBootloader.m
@@ -1,7 +1,12 @@
 /* Copyright Airship and Contributors */
 
 #import "RTNAirshipBootloader.h"
-#import "react_nativE_airship-Swift.h"
+
+#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
+#import <react_native_airship/react_native_airship-Swift.h>
+#else
+#import "react_native_airship-Swift.h"
+#endif
 
 @implementation RTNAirshipBootloader
 

--- a/ios/RTNAirshipMessageView.mm
+++ b/ios/RTNAirshipMessageView.mm
@@ -1,7 +1,12 @@
 /* Copyright Airship and Contributors */
 
 #import "RTNAirshipMessageView.h"
+
+#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
+#import <react_native_airship/react_native_airship-Swift.h>
+#else
 #import "react_native_airship-Swift.h"
+#endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTConversions.h>


### PR DESCRIPTION
<!--

Please fill out this template when submitting an pull request.

All lines beginning with an ℹ symbol indicate information that's
important for you to provide to ensure your pull request is reviewed
as quickly and efficiently as possible.

-->

### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->

Fixes an issue when iOS build would error when using Cocapods frameworks. I.e. setting the `use_frameworks` configuration.

Resolves issues #495 

### Why are these changes necessary?
<!-- ℹ Please provide a concise description of why your changes are
necessary here. -->

To be able to use the `use_frameworks` to enable dynamic / static frameworks on iOS.

### How did you verify these changes?
<!-- ℹ Please provide any relevant steps to verify or test your work. Make
this description clear enough so someone unfamiliar with your work could
verify for you. -->

Tested running the example app with first installing the Podfile using:

```
NO_FLIPPER=1 USE_FRAMEWORKS="static" pod install
```

then building and running the example app using Xcode.
