### PR TITLE
Release 15.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # React Native Module Changelog
 
-## Version 15.2.2 - April 6 2023
+## Version 15.2.3 - April 18, 2023
+
+Patch release that fixes a crash on Android when running an Android device older than 7. Apps that target API 23 or older should update.
+
+### Changes
+- Fixed Android crash due to using method `Map#putIfAbsent` on older Android devices.
+
+## Version 15.2.2 - April 6, 2023
 
 Patch release that fixes Android Preference Center subscription list state when switching named users.
 Apps using Preference Center that apply multiple named user IDs during an app session on Android should update.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,7 +4,7 @@ Airship_targetSdkVersion=31
 Airship_compileSdkVersion=31
 Airship_ndkversion=21.4.7075529
 
-Airship_airshipProxyVersion=2.0.4
+Airship_airshipProxyVersion=2.0.5
 
 # workaround for now, used for HMS
 Airship_airshipVersion=16.9.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "15.2.2",
+  "version": "15.2.3",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   
   
 
-  s.dependency "AirshipFrameworkProxy", "2.0.4"
+  s.dependency "AirshipFrameworkProxy", "2.0.5"
 
 end


### PR DESCRIPTION
Updates the proxy library to remove usage of putIfAbsent so we can be backwards compatible with Android 23 and older.

- [x] Verify events still work on Android 

https://github.com/Expensify/App/issues/17541