### PR TITLE
Release 15.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # React Native Module Changelog
 
+## Version 15.2.6 - May 17, 2023
+
+Patch release that fixes an issue with delivering push received events on Android when the app has not been loaded. This
+regression was introduced in 15.0.0, apps trying to process a push in the background should update.
+
+### Changes
+- Fixed push received events not delivering if the app is not loaded on Android
+
 ## Version 15.2.5 - May 3, 2023
 
 Patch release that fixes an issue with modifying attributes on iOS. Apps that are using

--- a/android/src/main/java/com/urbanairship/reactnative/AirshipHeadlessEventService.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipHeadlessEventService.kt
@@ -22,7 +22,7 @@ class AirshipHeadlessEventService : HeadlessJsTaskService() {
 
     override fun onHeadlessJsTaskFinish(taskId: Int) {
         super.onHeadlessJsTaskFinish(taskId)
-        ProxyLogger.error("AirshipHeadlessEventService - Finished")
+        ProxyLogger.verbose("AirshipHeadlessEventService - Finished")
     }
 
     companion object {
@@ -38,7 +38,7 @@ class AirshipHeadlessEventService : HeadlessJsTaskService() {
                     return true
                 }
             } catch (e: Exception) {
-                ProxyLogger.info("AirshipHeadlessEventService - Failed to start service", e)
+                ProxyLogger.warn("AirshipHeadlessEventService - Failed to start service", e)
             }
             return false
         }

--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -15,6 +15,7 @@ import com.urbanairship.json.JsonSerializable
 import com.urbanairship.json.JsonValue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -55,11 +56,11 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
         MainScope().launch {
             // Background events will create a headless JS task in ReactAutopilot since
             // initialized wont be called until we have a JS task.
-            EventEmitter.shared().pendingEventListener.collect {
-                if (it.isForeground()) {
-                    notifyPending()
-                }
-            }
+            EventEmitter.shared().pendingEventListener
+                    .filter { it.isForeground() }
+                    .collect {
+                        notifyPending()
+                    }
         }
 
         context.addLifecycleEventListener(object : LifecycleEventListener {
@@ -119,7 +120,6 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
                             it.isForeground()
                         }
                     }
-
 
             val result = JsonValue.wrapOpt(EventEmitter.shared().takePending(eventTypes).map { it.body })
             ProxyLogger.verbose("Taking events: $eventName, isHeadlessJS: $isHeadlessJS, filteredTypes:$eventTypes, result: $result")

--- a/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/ReactAutopilot.kt
@@ -12,6 +12,7 @@ import com.urbanairship.android.framework.proxy.ProxyLogger
 import com.urbanairship.android.framework.proxy.ProxyStore
 import com.urbanairship.android.framework.proxy.events.EventEmitter
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 
 /**
@@ -27,12 +28,11 @@ class ReactAutopilot : BaseAutopilot() {
         val context = UAirship.getApplicationContext()
 
         MainScope().launch {
-            EventEmitter.shared().pendingEventListener.collect {
-                ProxyLogger.error("On event $it")
-                if (!it.isForeground()) {
-                    AirshipHeadlessEventService.startService(context)
-                }
-            }
+            EventEmitter.shared().pendingEventListener
+                    .filter { !it.isForeground() }
+                    .collect {
+                        AirshipHeadlessEventService.startService(context)
+                    }
         }
 
         // Set our custom notification provider

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -318,7 +318,7 @@ PODS:
   - React-jsinspector (0.71.1)
   - React-logger (0.71.1):
     - glog
-  - react-native-airship (15.2.4):
+  - react-native-airship (15.2.6):
     - AirshipFrameworkProxy (= 2.0.8)
     - React-Core
   - react-native-safe-area-context (4.5.0):
@@ -617,7 +617,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
   React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  react-native-airship: bc612d662fdd571b391b980583d7749169f430d4
+  react-native-airship: 5d19f4ba303481cf4101ff9dee9249ef6a8a6b64
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
   React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "15.2.5",
+  "version": "15.2.6",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
When we switched to a turbo package, the module no longer initialized on app start, even if I set the flag to eagerInit. It still will wait for a react context. I had to move the event listener to start the headlessjs task in autopilot to work around this.