### PR TITLE
Release 16.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # React Native Module Changelog
+ 
+## Version 16.0.1 - July 21, 2023
+Patch release that updates the iOS and Android Airship SDK to 17.0.3.
+
+### Changes
+- Updated iOS SDK to 17.0.3
+- Updated Android SDK to 17.0.3
+- Fixed Android HMS module version
 
 ## Version 16.0.0 - June 27, 2023
 Major release that updates the iOS & Android Airship SDK to 17.0.2. This release adds support for Stories, In-App experiences downstream of a sequence in Journeys, and improves SDK auth. The Airship SDK now requires iOS 14+ as the minimum deployment version and Xcode 14.3+.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,8 +4,8 @@ Airship_targetSdkVersion=31
 Airship_compileSdkVersion=31
 Airship_ndkversion=21.4.7075529
 
-Airship_airshipProxyVersion=3.0.1
+Airship_airshipProxyVersion=3.0.2
 
 # workaround for now, used for HMS
-Airship_airshipVersion=7.0.2
+Airship_airshipVersion=17.0.3
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Airship (17.0.2):
-    - Airship/Automation (= 17.0.2)
-    - Airship/Basement (= 17.0.2)
-    - Airship/Core (= 17.0.2)
-    - Airship/MessageCenter (= 17.0.2)
-    - Airship/PreferenceCenter (= 17.0.2)
-  - Airship/Automation (17.0.2):
+  - Airship (17.0.3):
+    - Airship/Automation (= 17.0.3)
+    - Airship/Basement (= 17.0.3)
+    - Airship/Core (= 17.0.3)
+    - Airship/MessageCenter (= 17.0.3)
+    - Airship/PreferenceCenter (= 17.0.3)
+  - Airship/Automation (17.0.3):
     - Airship/Core
-  - Airship/Basement (17.0.2)
-  - Airship/Core (17.0.2):
+  - Airship/Basement (17.0.3)
+  - Airship/Core (17.0.3):
     - Airship/Basement
-  - Airship/MessageCenter (17.0.2):
+  - Airship/MessageCenter (17.0.3):
     - Airship/Core
-  - Airship/PreferenceCenter (17.0.2):
+  - Airship/PreferenceCenter (17.0.3):
     - Airship/Core
-  - AirshipFrameworkProxy (3.0.1):
-    - Airship (= 17.0.2)
+  - AirshipFrameworkProxy (3.0.2):
+    - Airship (= 17.0.3)
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -314,15 +314,11 @@ PODS:
   - React-jsinspector (0.71.1)
   - React-logger (0.71.1):
     - glog
-  - react-native-airship (16.0.0):
-    - AirshipFrameworkProxy (= 3.0.1)
+  - react-native-airship (16.0.1):
+    - AirshipFrameworkProxy (= 3.0.2)
     - React-Core
-  - react-native-safe-area-context (4.5.0):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-safe-area-context (4.7.1):
     - React-Core
-    - ReactCommon/turbomodule/core
   - React-perflogger (0.71.1)
   - React-RCTActionSheet (0.71.1):
     - React-Core/RCTActionSheetHeaders (= 0.71.1)
@@ -404,9 +400,9 @@ PODS:
     - React-jsi (= 0.71.1)
     - React-logger (= 0.71.1)
     - React-perflogger (= 0.71.1)
-  - RNGestureHandler (2.9.0):
+  - RNGestureHandler (2.12.0):
     - React-Core
-  - RNScreens (3.19.0):
+  - RNScreens (3.22.1):
     - React-Core
     - React-RCTImage
   - SocketRocket (0.6.1)
@@ -578,8 +574,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: f3cb26f1c1e8c12af2bca269d4a5f6eaa3f2c786
-  AirshipFrameworkProxy: 1b699b2bca73ec5251025086342a4a977dd2cd60
+  Airship: 9fdd1ccc3a78c42544f34b7de043d39491951023
+  AirshipFrameworkProxy: 9a0a26b1b117fe3ccbe1b2d4a9053875e2c0d6d2
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -613,8 +609,8 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
   React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  react-native-airship: c7393a0e51eae39822e3e11536a73c5a543a2f30
-  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
+  react-native-airship: 68a842b1002cabb9e8f12a13cbf7c38260eae868
+  react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
   React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de
   React-RCTAnimation: 168d53718c74153947c0109f55900faa64d79439
@@ -628,12 +624,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: 49d531ec8498e0afa2c9b22c2205784372e3d4f3
   React-runtimeexecutor: 311feb67600774723fe10eb8801d3138cae9ad67
   ReactCommon: 03be76588338a27a88d103b35c3c44a3fd43d136
-  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
+  RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
+  RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 921eb014669cf9c718ada68b08d362517d564e0c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: b7a94a3aefc53b758c07410e8e9ddbf2ee273556
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -36,7 +36,7 @@ public class AirshipReactNative: NSObject {
         AirshipProxy.shared
     }
 
-    public static let version: String = "15.2.2"
+    public static let version: String = "16.0.1"
 
     private let eventNotifier = EventNotifier()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   
   
 
-  s.dependency "AirshipFrameworkProxy", "3.0.1"
+  s.dependency "AirshipFrameworkProxy", "3.0.2"
 
 end


### PR DESCRIPTION
## Version 16.0.1 - July 21, 2023
Patch release that updates the iOS and Android Airship SDK to 17.0.3.

### Changes
- Updated iOS SDK to 17.0.3
- Updated Android SDK to 17.0.3
- Fixed Android HMS module version
