### PR TITLE
Fix old architecture channelEditTags method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # React Native Module Changelog
 
+## Version 16.1.1 - September 22, 2023
+Patch release that updates the iOS SDK to 17.3.1 and fixes Channel Tag Editor for React Native old architechture.
+
+### Changes
+- Updated iOS SDK to 17.3.1
+- Fixed `Airship.channel.editTags()` for React Native old architechture
+
 ## Version 16.1.0 - September 11, 2023
 Minor release that updates the iOS SDK to 17.3.0 and Android SDK to 17.2.1. Also adds support for Airship Feature Flag feature and for Channel Tag Editor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # React Native Module Changelog
 
 ## Version 16.1.1 - September 22, 2023
-Patch release that updates the iOS SDK to 17.3.1 and fixes Channel Tag Editor for React Native old architechture.
+Patch release that updates the iOS SDK to 17.3.1 and fixes Channel Tag Editor for React Native old architecture.
 
 ### Changes
 - Updated iOS SDK to 17.3.1
-- Fixed `Airship.channel.editTags()` for React Native old architechture
+- Fixed `Airship.channel.editTags()` for React Native old architecture
 
 ## Version 16.1.0 - September 11, 2023
 Minor release that updates the iOS SDK to 17.3.0 and Android SDK to 17.2.1. Also adds support for Airship Feature Flag feature and for Channel Tag Editor.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,7 +4,7 @@ Airship_targetSdkVersion=31
 Airship_compileSdkVersion=31
 Airship_ndkversion=21.4.7075529
 
-Airship_airshipProxyVersion=4.2.0
+Airship_airshipProxyVersion=4.3.0
 
 # workaround for now, used for HMS
 Airship_airshipVersion=17.2.1

--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -161,7 +161,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
-    override fun channelEditTags(operations: ReadableArray, promise: Promise) {
+    override fun channelEditTags(operations: ReadableArray?, promise: Promise) {
         promise.resolveResult {
             proxy.channel.editTags(Utils.convertArray(operations).toJsonValue())
         }

--- a/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
+++ b/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
@@ -62,6 +62,13 @@ abstract class AirshipSpec internal constructor(context: ReactApplicationContext
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
+    abstract fun channelEditTags(
+        operations: ReadableArray?,
+        promise: Promise
+    )
+
+    @ReactMethod
+    @com.facebook.proguard.annotations.DoNotStrip
     abstract fun channelEditAttributes(
         operations: ReadableArray?,
         promise: Promise

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - Airship (17.3.0):
-    - Airship/Automation (= 17.3.0)
-    - Airship/Basement (= 17.3.0)
-    - Airship/Core (= 17.3.0)
-    - Airship/FeatureFlags (= 17.3.0)
-    - Airship/MessageCenter (= 17.3.0)
-    - Airship/PreferenceCenter (= 17.3.0)
-  - Airship/Automation (17.3.0):
+  - Airship (17.3.1):
+    - Airship/Automation (= 17.3.1)
+    - Airship/Basement (= 17.3.1)
+    - Airship/Core (= 17.3.1)
+    - Airship/FeatureFlags (= 17.3.1)
+    - Airship/MessageCenter (= 17.3.1)
+    - Airship/PreferenceCenter (= 17.3.1)
+  - Airship/Automation (17.3.1):
     - Airship/Core
-  - Airship/Basement (17.3.0)
-  - Airship/Core (17.3.0):
+  - Airship/Basement (17.3.1)
+  - Airship/Core (17.3.1):
     - Airship/Basement
-  - Airship/FeatureFlags (17.3.0):
+  - Airship/FeatureFlags (17.3.1):
     - Airship/Core
-  - Airship/MessageCenter (17.3.0):
+  - Airship/MessageCenter (17.3.1):
     - Airship/Core
-  - Airship/PreferenceCenter (17.3.0):
+  - Airship/PreferenceCenter (17.3.1):
     - Airship/Core
-  - AirshipFrameworkProxy (4.2.0):
-    - Airship (= 17.3.0)
+  - AirshipFrameworkProxy (4.3.0):
+    - Airship (= 17.3.1)
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -317,8 +317,8 @@ PODS:
   - React-jsinspector (0.71.1)
   - React-logger (0.71.1):
     - glog
-  - react-native-airship (16.1.0):
-    - AirshipFrameworkProxy (= 4.2.0)
+  - react-native-airship (16.1.1):
+    - AirshipFrameworkProxy (= 4.3.0)
     - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
@@ -581,8 +581,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 73ee3648eb6864be959246427e084b60536ae0dc
-  AirshipFrameworkProxy: a6e3e4357e6d65dd33c5bec39219a859762709c1
+  Airship: a8ec7140cca677696f10f605749c18248d818117
+  AirshipFrameworkProxy: 581e2ca4c3b2377724d0235117d617df8489097a
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -616,7 +616,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 60cf272aababc5212410e4249d17cea14fc36caa
   React-jsinspector: ff56004b0c974b688a6548c156d5830ad751ae07
   React-logger: 60a0b5f8bed667ecf9e24fecca1f30d125de6d75
-  react-native-airship: a254a0fb81c4ebe6dccc95c7644b5b84c90adc65
+  react-native-airship: a7222b49a0cfa0bdd9dc3981c15f808a9ae90740
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   React-perflogger: ec8eef2a8f03ecfa6361c2c5fb9197ef4a29cc85
   React-RCTActionSheet: a0c023b86cf4c862fa9c4eb0f6f91fbe878fb2de

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -36,7 +36,7 @@ public class AirshipReactNative: NSObject {
         AirshipProxy.shared
     }
 
-    public static let version: String = "16.1.0"
+    public static let version: String = "16.1.1"
 
     private let eventNotifier = EventNotifier()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |s|
   
   
 
-  s.dependency "AirshipFrameworkProxy", "4.2.0"
+  s.dependency "AirshipFrameworkProxy", "4.3.0"
 
 end


### PR DESCRIPTION
This fixes an issue with channelEditTags for the old architecture.  When an interface is changed we have to manually update the old arch spec. 

I will add a follow up ticket to update the CI to build both arch types for Android and iOS to make sure we are not missing anything