### PR TITLE
Crash when using Airship.push.getActiveNotifications()

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -249,7 +249,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     @ReactMethod
     override fun pushGetActiveNotifications(promise: Promise) {
         promise.resolveResult {
-            proxy.push.getActiveNotifications()
+            JsonValue.wrapOpt(proxy.push.getActiveNotifications())
         }
     }
 


### PR DESCRIPTION
### What do these changes do?
Fix the crash when using getActiveNotifications() on Android

### How did you verify these changes?
Test on the sample app on Android and iOS 

#### Verification Screenshots:
<img width="1439" alt="image" src="https://github.com/urbanairship/react-native-airship/assets/15062214/8e1e1d8f-9b25-4b8b-9edd-dd8b282a2fdf">
