### PR TITLE
[MOBILE-3980] Add enableChannelCreation method

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -147,6 +147,13 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
+    override fun channelEnableChannelCreation(promise: Promise) {
+        promise.resolveResult {
+            proxy.channel.enableChannelCreation()
+        }
+    }
+
+    @ReactMethod
     override fun channelAddTag(tag: String?, promise: Promise) {
         promise.resolveResult {
             proxy.channel.addTag(requireNotNull(tag))

--- a/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
+++ b/android/src/oldarch/java/com/urbanairship/reactnative/AirshipSpec.kt
@@ -35,6 +35,10 @@ abstract class AirshipSpec internal constructor(context: ReactApplicationContext
 
     @ReactMethod
     @com.facebook.proguard.annotations.DoNotStrip
+    abstract fun channelEnableChannelCreation(promise: Promise)
+
+    @ReactMethod
+    @com.facebook.proguard.annotations.DoNotStrip
     abstract fun channelAddTag(tag: String?, promise: Promise)
 
     @ReactMethod

--- a/ios/RTNAirship.mm
+++ b/ios/RTNAirship.mm
@@ -117,6 +117,15 @@ RCT_REMAP_METHOD(channelEditTags,
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
 
+RCT_REMAP_METHOD(channelEnableChannelCreation,
+                 channelEnableChannelCreation:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+    NSError *error;
+    [AirshipReactNative.shared channelEnableChannelCreationAndReturnError:&error];
+
+    [self handleResult:nil error:error resolve:resolve reject:reject];
+}
+
 RCT_REMAP_METHOD(pushGetActiveNotifications,
                  pushGetActiveNotifications:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {

--- a/src/AirshipChannel.ts
+++ b/src/AirshipChannel.ts
@@ -12,6 +12,16 @@ export class AirshipChannel {
   constructor(private readonly module: any) {}
 
   /**
+   * Enables channel creation if channel creation has been delayed.
+   * It is only necessary to call this when isChannelCreationDelayEnabled
+   * has been set to `true` in the airship config.
+   * Deprecated. Use the Private Manager to disable all features instead.
+   */
+  public enableChannelCreation(): Promise<void> {
+    return this.module.channelEnableChannelCreation();
+  }
+
+  /**
    * Adds a device tag.
    * Deprecated. Use editTags() instead.
    * @param tag The tag.

--- a/src/NativeRTNAirship.ts
+++ b/src/NativeRTNAirship.ts
@@ -14,6 +14,7 @@ export interface Spec extends TurboModule {
   removeListeners: (count: number) => void;
 
   // Channel
+  channelEnableChannelCreation(): Promise<void>;
   channelAddTag(tag: string): Promise<void>;
   channelRemoveTag(tag: string): Promise<void>;
   channelEditTags(operations: Object[]): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,7 @@ export interface AirshipConfig {
 
   /**
    * Enables delayed channel creation.
+   * Deprecated. Use the Private Manager to disable all features instead.
    */
   isChannelCreationDelayEnabled?: boolean;
 


### PR DESCRIPTION
### What do these changes do?
Add an enableChannelCreation method and mark it as deprecated along with the isChannelCreationDelayEnabled config.

### Why are these changes necessary?
To not block people that would still use the isChannelCreationDelayEnabled config.

### How did you verify these changes?
Tested on iOS.
Android is working fine at APK.On my side, something with my environment is blocking for now, about CMake in the NDK...

#### Verification Screenshots:

### Anything else a reviewer should know?
