### PR TITLE
Check ExtraProperties for "airshipHmsEnabled" additionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ def isNewArchitectureEnabled() {
 }
 
 def isHmsEnabled() {
-    return rootProject.hasProperty("airshipHmsEnabled") && rootProject.getProperty("airshipHmsEnabled") == "true"
+    return (rootProject.hasProperty("airshipHmsEnabled") && rootProject.getProperty("airshipHmsEnabled") == "true") || (rootProject.ext.has("airshipHmsEnabled") && rootProject.ext.get("airshipHmsEnabled") == "true")
 }
 
 def resolveReactNativeDirectory() {


### PR DESCRIPTION
### What do these changes do?
Check for the "airshipHmsEnabled" flag in ExtraProperties from build.gradle on android top level additionally to check in gradle.properties.

### Why are these changes necessary?
HMS requires "com.huawei.hms:push", which then requires the REQUEST_INSTALL_PACKAGES permission. This permission is considered as "high risk or sensitive permission" by Google (see https://support.google.com/googleplay/android-developer/answer/12085295?hl=en). 

Making the "airshipHmsEnabled" flag available in ExtraProperties of the root projects makes it easier to control wether HMS should be used or not in react native apps which are build for HarmonyOS and Android at the same time. By that we can avoid the whole "REQUEST_INSTALL_PACKAGES" mess in Playstore easier, because changing values in build.gradle files can be done with less effort.

### How did you verify these changes?
Tested in a RN app, "airshipHmsEnabled" not set in gradle.properties but in build.gradle on android top level. HMS still worked.
