### PR TITLE
fix(android): missing annotation on feature flag method

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -648,6 +648,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
         }
     }
 
+    @ReactMethod
     override fun featureFlagManagerFlag(flagName: String?, promise: Promise) {
         promise.resolveDeferred { callback ->
             scope.launch {
@@ -662,6 +663,7 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
         }
     }
 
+    @ReactMethod
     override fun featureFlagManagerTrackInteraction(flag: ReadableMap?, promise: Promise) {
         promise.resolveResult {
             val parsedFlag = FeatureFlagProxy(Utils.convertMap(requireNotNull(flag)).toJsonValue())


### PR DESCRIPTION
### What do these changes do?
The `featureFlagManagerFlag` and `featureFlagManagerTrackInteraction` missed out the annotation to make it accessible from JS for Android native-module

### Why are these changes necessary?
Without this annotation, we can't use the `flag` and `trackInteraction` method on Android.

### How did you verify these changes?
Added the annotation, rebuild the app, and verify that the method able to call the native method

Should fix https://github.com/urbanairship/react-native-airship/issues/540