### PR TITLE
Fix listIconUrl definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -562,7 +562,7 @@ export interface InboxMessage {
   /**
    * Optional - The icon url for the message.
    */
-  listIconUrl: string;
+  listIconUrl?: string;
   /**
    * The unread / read status of the message.
    */


### PR DESCRIPTION
Fixes the listIconUrl definition to match the original specification and its comment. Will take a look to see if anything else needs updating. 