### PR TITLE
[MOBILE-4628] Add Webview inspection check in MessageCenter

### DIFF
--- a/ios/MessageWebViewWrapper.swift
+++ b/ios/MessageWebViewWrapper.swift
@@ -67,6 +67,10 @@ class _MessageWebViewWrapper: NSObject, UANavigationDelegate, NativeBridgeDelega
         self.nativeBridge.nativeBridgeDelegate = self
         self.webView.navigationDelegate = self.nativeBridge
         self.webView.configuration.dataDetectorTypes = .all
+
+        if #available(iOS 16.4, *) {
+            self.webView.isInspectable = Airship.isFlying && Airship.config.isWebViewInspectionEnabled
+        }
     }
 
     @MainActor

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,11 +481,15 @@ export interface AirshipConfig {
      */
     itunesId?: string;
 
-
     /**
      * If set to `true`, the SDK will use the preferred locale. Otherwise it will use the app's locale.
      */
     useUserPreferredLocale?: boolean;
+
+    /**
+     * Allows the WebViews to be inspected in Safari.
+     */
+    isWebViewInspectionEnabled?: boolean;
   };
 
   /**


### PR DESCRIPTION
### What do these changes do?
- Add a check in Message Center to allow the webview to be inspected in Safari
- Add a config field for isWebViewInspectionEnabled

### Why are these changes necessary?
To debug more easily the webviews

### How did you verify these changes?
Putting isWebViewInspectionEnabled to true, running the sample app and inspecting the webview on Safari

#### Verification Screenshots:
![image](https://github.com/user-attachments/assets/44fbf7f3-ec87-47d2-b455-1d6b1bcc9ce2)

### Anything else a reviewer should know?
To make testing faster and easier I edited the ProxyConfig so it loads the new field from the config, so I think it would be great to add it in the next Proxy update

![image](https://github.com/user-attachments/assets/ebc41664-1534-430f-8592-0c1a2461d392)