### PR TITLE
Release 21.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # React Native Module Changelog
 
+## Version 21.2.0 - February 24, 2025
+Patch release that updates the Android SDK to 19.2.0 and the iOS SDK to 19.1.0.
+
+### Changes
+- Updated Android SDK to [19.2.0](https://github.com/urbanairship/android-library/releases/tag/19.2.0)
+- Updated iOS SDK to [19.1.0](https://github.com/urbanairship/ios-library/releases/tag/19.1.0)
+
 ## Version 21.1.0 - February 12, 2025
 Patch release that updates the Android SDK to 19.1.0 and fixes the `messageUnreadCount` on the `MessageCenterUpdated` event.
-
 
 ### Changes
 - Updated Android SDK to [19.1.0](https://github.com/urbanairship/android-library/releases/tag/19.1.0)
 - Fixed MessageCenterUpdatedEvent.messageUnreadCount on iOS.
-
 
 ## Version 21.0.2 - February 6, 2025
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=35
 Airship_compileSdkVersion=35
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=13.0.1
+Airship_airshipProxyVersion=13.1.0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
-  - Airship (19.0.3):
-    - Airship/Automation (= 19.0.3)
-    - Airship/Basement (= 19.0.3)
-    - Airship/Core (= 19.0.3)
-    - Airship/FeatureFlags (= 19.0.3)
-    - Airship/MessageCenter (= 19.0.3)
-    - Airship/PreferenceCenter (= 19.0.3)
-  - Airship/Automation (19.0.3):
+  - Airship (19.1.0):
+    - Airship/Automation (= 19.1.0)
+    - Airship/Basement (= 19.1.0)
+    - Airship/Core (= 19.1.0)
+    - Airship/FeatureFlags (= 19.1.0)
+    - Airship/MessageCenter (= 19.1.0)
+    - Airship/PreferenceCenter (= 19.1.0)
+  - Airship/Automation (19.1.0):
     - Airship/Core
-  - Airship/Basement (19.0.3)
-  - Airship/Core (19.0.3):
+  - Airship/Basement (19.1.0)
+  - Airship/Core (19.1.0):
     - Airship/Basement
-  - Airship/FeatureFlags (19.0.3):
+  - Airship/FeatureFlags (19.1.0):
     - Airship/Core
-  - Airship/MessageCenter (19.0.3):
+  - Airship/MessageCenter (19.1.0):
     - Airship/Core
-  - Airship/PreferenceCenter (19.0.3):
+  - Airship/PreferenceCenter (19.1.0):
     - Airship/Core
-  - AirshipFrameworkProxy (13.0.1):
-    - Airship (= 19.0.3)
-  - AirshipServiceExtension (19.0.3)
+  - AirshipFrameworkProxy (13.1.0):
+    - Airship (= 19.1.0)
+  - AirshipServiceExtension (19.1.0)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.4)
@@ -907,8 +907,8 @@ PODS:
   - React-Mapbuffer (0.73.4):
     - glog
     - React-debug
-  - react-native-airship (21.1.0):
-    - AirshipFrameworkProxy (= 13.0.1)
+  - react-native-airship (21.2.0):
+    - AirshipFrameworkProxy (= 13.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1279,9 +1279,9 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: cb24c861b4ab7023a71acd977960475042b35eb5
-  AirshipFrameworkProxy: 28e83f92745833cc2d9e4fe0e49687a334352d53
-  AirshipServiceExtension: b56d3c476943daf39b9f45ee8f9ef0240248170a
+  Airship: eb4783c5465b9440a995169bdabfa6194ca8e3c5
+  AirshipFrameworkProxy: b1fcfbbde135f878f39e6c2e354f456b961271ca
+  AirshipServiceExtension: a2c1821277cc919b6b47dff8a5052562292d843d
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
@@ -1290,56 +1290,56 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: b2669ce35fc4ac14f523b307aff8896799829fe2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
+  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: ab7f915c15569f04a49669e573e6e319a53f9faa
   RCTTypeSafety: 63b97ced7b766865057e7154db0e81ce4ee6cf1e
   React: 1c87497e50fa40ba9c54e5ea5e53483a0f8eecc0
   React-callinvoker: e3a52a9a93e3eb004d7282c26a4fb27003273fe6
-  React-Codegen: accd8617d26d9e8192f2105e2b715f346bbd6888
-  React-Core: e063354ccbed01b836af1e6e94b5cb8319097104
-  React-CoreModules: db63015ed3e85382f6d8ec7f78b5136cfb345c18
-  React-cxxreact: 7e569c1f7e4dda58ba17df36450c6d98df407b5b
+  React-Codegen: 50c0f8f073e71b929b057b68bf31be604f1dccc8
+  React-Core: d0ecde72894b792cb8922efaa0990199cbe85169
+  React-CoreModules: 2ff1684dd517f0c441495d90a704d499f05e9d0a
+  React-cxxreact: d9be2fac926741052395da0a6d0bab8d71e2f297
   React-debug: 4678e73a37cb501d784e99ff0f219b4940362a3b
-  React-Fabric: a6a9148a530e4b5e984f5f3373b07ee0a2e41f45
-  React-FabricImage: 701972b5524a7a6a02710b55f0f6a82e94bd7da8
-  React-graphics: 46697b8481d17ead6e346f2cbdeee443eff3fd18
-  React-hermes: a29dacf053e80ebe20b680e30afe26580521e0c9
-  React-ImageManager: 9ae8207447796390d7b78beffd7aec8dc28311c4
-  React-jserrorhandler: e53f2eee7b67787ac8bfb6a709ac4eecdb57c2e9
-  React-jsi: 6db2f81ad41fc50394a70af6e38dd23ac483ff79
-  React-jsiexecutor: 951f2809bea7cab011dd1bbe06c631c75df4f673
+  React-Fabric: 460ee9d4b8b9de3382504a711430bfead1d5be1e
+  React-FabricImage: d0a0631bc8ad9143f42bfccf9d3d533a144cc3d6
+  React-graphics: f0d5040263a9649e2a70ebe27b3120c49411afef
+  React-hermes: b9ac2f7b0c1eeb206eb883583cab7a973d570a6e
+  React-ImageManager: 6c4bf9d5ed363ead7b5aaf820a3feab221b7063e
+  React-jserrorhandler: 6e7a7e187583e14dc7a0053a2bdd66c252ea3b21
+  React-jsi: 380cd24dd81a705dd042c18989fb10b07182210c
+  React-jsiexecutor: 8ed7a18b9f119440efdcd424c8257dc7e18067e2
   React-jsinspector: 9ac353eccf6ab54d1e0a33862ba91221d1e88460
-  React-logger: 5295f5eac9d7624fe9a33a473442d8f4c1074197
-  React-Mapbuffer: f7ba4d5459e546d741791a55664388e97b31df7c
-  react-native-airship: 0cc50df3ce1edee224a470b4690063188c8a5543
-  react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
+  React-logger: 0a57b68dd2aec7ff738195f081f0520724b35dab
+  React-Mapbuffer: 63913773ed7f96b814a2521e13e6d010282096ad
+  react-native-airship: 0a11933144d0b4f491e78541fa0403a7c7ed4736
+  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
-  React-NativeModulesApple: 7a561c2792b0a2b74aff6c58d2554dcf824372aa
+  React-NativeModulesApple: 0123905d5699853ac68519607555a9a4f5c7b3ac
   React-perflogger: 8a1e1af5733004bdd91258dcefbde21e0d1faccd
   React-RCTActionSheet: 64bbff3a3963664c2d0146f870fe8e0264aee4c4
-  React-RCTAnimation: 548fdbd189275f721a4f3098da847a84e3e3339f
-  React-RCTAppDelegate: 7d6c7ca4a9d94c889533ad6730782f176ff4b43a
-  React-RCTBlob: 7bf2d87c667d5a570212d921583dca5e1156395c
-  React-RCTFabric: d3eee95226b91877334fefbbd4d48122f114506b
-  React-RCTImage: 8ad4a0f9e728ff81a229446a6a8de8657c133cc6
-  React-RCTLinking: 12c1070797c9242b8ca2d171fc43588de47e442d
-  React-RCTNetwork: 1a59d000d0053f56f405d52521ae9df1b6108aa3
-  React-RCTSettings: a3b91c385e2f3bc7aa2bae75b2f60c6fd0c9052e
-  React-RCTText: 78330d21c9d14d680f31a3a3866436b978a66a8c
-  React-RCTVibration: 632344d1fdb7f1d568d1c6715f2dfe270fff6e88
-  React-rendererdebug: 740d4bbbbea219809a58cde58c8af0e39c787831
+  React-RCTAnimation: b698168a7269265a4694727196484342d695f0c1
+  React-RCTAppDelegate: dcd8e955116eb1d1908dfaf08b4c970812e6a1e6
+  React-RCTBlob: 47f8c3b2b4b7fa2c5f19c43f0b7f77f57fb9d953
+  React-RCTFabric: 6067a32d683d0c2b84d444548bc15a263c64abed
+  React-RCTImage: ac0e77a44c290b20db783649b2b9cddc93e3eb99
+  React-RCTLinking: e626fd2900913fe5d25922ea1be394b7aafa09c9
+  React-RCTNetwork: d3114bce3977dafe8bd06421b29812f5a8527ba0
+  React-RCTSettings: a53511f90d8df637a1a11ac729179a4d2f734481
+  React-RCTText: f0176f5f5952f9a4a2c7354f5ae71f7c420aaf34
+  React-RCTVibration: 8160223c6eda5b187079fec204f80eca8b8f3177
+  React-rendererdebug: ed286b4da8648c27d6ed3ae1410d4b21ba890d5a
   React-rncore: 43f133b89ac10c4b6ab43702a541dee1c292a3bf
   React-runtimeexecutor: e6ab6bb083dbdbdd489cff426ed0bce0652e6edf
-  React-runtimescheduler: ceaeeb19e75912958625f72883d240640e8f40da
-  React-utils: 8439db27c3745f6de9d67eb61f5600c8d624274c
-  ReactCommon: cc18bd33c0fab03c67620da6a602dcc1704e66b4
-  RNCClipboard: 4abb037e8fe3b98a952564c9e0474f91c492df6d
-  RNGestureHandler: 2a76de24abfbdfdc7a7a5fcb4b5e57563ada065e
-  RNScreens: 8d1521c6e375a79dbd4525efaf21704cc64ac0cf
-  RNVectorIcons: ff027ab4234109f91d261fbceae7f0bf95dcc479
+  React-runtimescheduler: ed48e5faac6751e66ee1261c4bd01643b436f112
+  React-utils: 6e5ad394416482ae21831050928ae27348f83487
+  ReactCommon: 840a955d37b7f3358554d819446bffcf624b2522
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
+  RNGestureHandler: deda62b8339496ba721a45e0f3e2d7a319932cee
+  RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
+  RNVectorIcons: 210f910e834e3485af40693ad4615c1ec22fc02b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
 PODFILE CHECKSUM: 50322234ec14b347050b85e0e18246a45e155b4a
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -39,7 +39,7 @@ public class AirshipReactNative: NSObject {
         AirshipProxy.shared
     }
 
-    public static let version: String = "21.1.0"
+    public static let version: String = "21.2.0"
 
     private let eventNotifier = EventNotifier()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "21.1.0",
+  "version": "21.2.0",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
   
-  s.dependency "AirshipFrameworkProxy", "13.0.1"
+  s.dependency "AirshipFrameworkProxy", "13.1.0"
 end


### PR DESCRIPTION
### What do these changes do?

Bumps Android to 19.2.0 and iOS to 19.1.0

### Why are these changes necessary?

Fixing a prepare assets bug on Android that allows messages to be displayed even if we've failed to pre-cache an image asset.
