### PR TITLE
Disable shipping generated code

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "src",
@@ -132,7 +133,6 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      "codegen",
       [
         "commonjs",
         {
@@ -171,7 +171,7 @@
         "RNAirshipEmbeddedView": "RNAirshipEmbeddedView"
       }
     },
-    "includesGeneratedCode": true
+    "includesGeneratedCode": false
   },
   "create-react-native-library": {
     "languages": "kotlin-objc",


### PR DESCRIPTION
ReactNative .78 added a new interface for view managers with generated code. Since this ships the generated code it cant find that interface on older react versions. Still testing

Followed https://callstack.github.io/react-native-builder-bob/faq