### PR TITLE
Release 21.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # React Native Module Changelog
 
+## Version 21.4.0 - April 3, 2025
+Minor release that updates the iOS SDK to 19.2.0 and backports the new `AirshipPluginExtensions`.
+
+### Changes
+- Updated iOS SDK to [19.2.0](https://github.com/urbanairship/ios-library/releases/tag/19.2.0)
+- Backported `AirshipPluginExtensions` from 23.0.0
+- Deprecated `AirshipPluginForwardListeners` and `AirshipPluginForwardDelegates`
+
 ## Version 21.3.0 - April 1, 2025
 Minor release that updates the Android SDK to 19.5.0 and the iOS SDK to 19.1.2.
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=35
 Airship_compileSdkVersion=35
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=13.3.1
+Airship_airshipProxyVersion=14.1.0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - Airship (19.1.2):
-    - Airship/Automation (= 19.1.2)
-    - Airship/Basement (= 19.1.2)
-    - Airship/Core (= 19.1.2)
-    - Airship/FeatureFlags (= 19.1.2)
-    - Airship/MessageCenter (= 19.1.2)
-    - Airship/PreferenceCenter (= 19.1.2)
-  - Airship/Automation (19.1.2):
+  - Airship (19.2.0):
+    - Airship/Automation (= 19.2.0)
+    - Airship/Basement (= 19.2.0)
+    - Airship/Core (= 19.2.0)
+    - Airship/FeatureFlags (= 19.2.0)
+    - Airship/MessageCenter (= 19.2.0)
+    - Airship/PreferenceCenter (= 19.2.0)
+  - Airship/Automation (19.2.0):
     - Airship/Core
-  - Airship/Basement (19.1.2)
-  - Airship/Core (19.1.2):
+  - Airship/Basement (19.2.0)
+  - Airship/Core (19.2.0):
     - Airship/Basement
-  - Airship/FeatureFlags (19.1.2):
+  - Airship/FeatureFlags (19.2.0):
     - Airship/Core
-  - Airship/MessageCenter (19.1.2):
+  - Airship/MessageCenter (19.2.0):
     - Airship/Core
-  - Airship/PreferenceCenter (19.1.2):
+  - Airship/PreferenceCenter (19.2.0):
     - Airship/Core
-  - AirshipFrameworkProxy (13.3.1):
-    - Airship (= 19.1.2)
+  - AirshipFrameworkProxy (14.1.0):
+    - Airship (= 19.2.0)
   - AirshipServiceExtension (19.1.2)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
@@ -907,8 +907,8 @@ PODS:
   - React-Mapbuffer (0.73.4):
     - glog
     - React-debug
-  - react-native-airship (21.3.0):
-    - AirshipFrameworkProxy (= 13.3.1)
+  - react-native-airship (21.4.0):
+    - AirshipFrameworkProxy (= 14.1.0)
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1279,8 +1279,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Airship: 5dbdbd554b3e6127e4066eab3b0021f86448bd92
-  AirshipFrameworkProxy: 7e602bbf4ff46d448230cfd9cd216608819239dc
+  Airship: 4f4dc8dc616703787bdf73869437ccd0a52c6db7
+  AirshipFrameworkProxy: 6b6bee0ef983258931a67f701f1171e9ded2d8c5
   AirshipServiceExtension: b97fc3d231d21833aa9a27cffab8d67accd8a4cc
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
@@ -1311,7 +1311,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 9ac353eccf6ab54d1e0a33862ba91221d1e88460
   React-logger: 5295f5eac9d7624fe9a33a473442d8f4c1074197
   React-Mapbuffer: f7ba4d5459e546d741791a55664388e97b31df7c
-  react-native-airship: 32eab13afb24100542d5bef13f2a16f8eeee719f
+  react-native-airship: 9c3bda9e4cf0230bd8457752a9d9ff4502945124
   react-native-safe-area-context: 435f4c13ac75ceed6135382ee77d57d1a5b5b2d6
   React-nativeconfig: d7af5bae6da70fa15ce44f045621cf99ed24087c
   React-NativeModulesApple: 7a561c2792b0a2b74aff6c58d2554dcf824372aa

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -39,7 +39,7 @@ public class AirshipReactNative: NSObject {
         AirshipProxy.shared
     }
 
-    public static let version: String = "21.3.0"
+    public static let version: String = "21.4.0"
 
     private let eventNotifier = EventNotifier()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ua/react-native-airship",
-  "version": "21.3.0",
+  "version": "21.4.0",
   "description": "Airship plugin for React Native apps.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
   
-  s.dependency "AirshipFrameworkProxy", "13.3.1"
+  s.dependency "AirshipFrameworkProxy", "14.1.0"
 end


### PR DESCRIPTION
Backports the latest proxy (14.1.0) to 21.x for older React Native users. 