### PR TITLE
RN and node version bump for the example app

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,23 +12,23 @@
   },
   "dependencies": {
     "moment": "^2.30.1",
-    "react": "19.0.0",
-    "react-native": "0.79.1"
+    "react": "19.1.0",
+    "react-native": "0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native-community/cli": "18.0.0",
-    "@react-native-community/cli-platform-android": "18.0.0",
-    "@react-native-community/cli-platform-ios": "18.0.0",
-    "@react-native/babel-preset": "0.79.1",
-    "@react-native/metro-config": "0.79.1",
-    "@react-native/typescript-config": "0.79.1",
-    "@types/react": "^19.0.0",
+    "@react-native-community/cli": "19.0.0",
+    "@react-native-community/cli-platform-android": "19.0.0",
+    "@react-native-community/cli-platform-ios": "19.0.0",
+    "@react-native/babel-preset": "0.80.0",
+    "@react-native/metro-config": "0.80.0",
+    "@react-native/typescript-config": "0.80.0",
+    "@types/react": "^19.1.0",
     "react-native-builder-bob": "^0.40.4"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19.0"
   }
 }


### PR DESCRIPTION
### What do these changes do?
bumps react native version to 0.80.0
bumps node version to 20.19.0

### Why are these changes necessary?
react-native-builder-bob@0.40.4 requires: { node: '^20.19.0 || ^22.12.0 || >= 23.4.0' } and without the proper node version will note generate RNAirship.h which leads to iOS build issue