### PR TITLE
Resolve RNAirshipMessageViewEventEmitter crash

### DIFF
--- a/ios/RNAirshipMessageView.mm
+++ b/ios/RNAirshipMessageView.mm
@@ -157,10 +157,12 @@ NSString *const RNAirshipMessageViewErrorKey = @"error";
 - (void)dispatchOnLoadFinishedEvent: (NSString*)messageID
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-    std::dynamic_pointer_cast<const facebook::react::RNAirshipMessageViewEventEmitter>(_eventEmitter)
-        ->onLoadFinished(facebook::react::RNAirshipMessageViewEventEmitter::OnLoadFinished{
-            .messageId = std::string([messageID UTF8String])
-        });
+  auto emitter = std::dynamic_pointer_cast<const facebook::react::RNAirshipMessageViewEventEmitter>(_eventEmitter);
+  if (emitter){
+    emitter->onLoadFinished(facebook::react::RNAirshipMessageViewEventEmitter::OnLoadFinished{
+      .messageId = std::string([messageID UTF8String])
+    });
+  }
 #else
     if (self.onLoadFinished) {
         self.onLoadFinished(@{RNAirshipMessageViewMessageIDKey: messageID });


### PR DESCRIPTION
### What do these changes do?
<!-- ℹ Please provide a description of your changes here. -->

### Why are these changes necessary?
The crash is in `React-Fabric: eventDispatche`r is a weak pointer, and for some reason the object it points to was already destroyed, so `.lock()` crashs.

### How did you verify these changes?
Sample app

#### Verification Screenshots:
<img width="954" height="424" alt="Screenshot 2025-08-26 at 17 46 10" src="https://github.com/user-attachments/assets/2a33b9cb-1f06-4019-b6d4-c65d29a14624" />

