### PR TITLE
Add Airship.getLaunchDeepLink for cold start deep links

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,4 @@ Airship_minSdkVersion=23
 Airship_targetSdkVersion=36
 Airship_compileSdkVersion=36
 Airship_ndkversion=26.1.10909125
-Airship_airshipProxyVersion=15.14.0
+Airship_airshipProxyVersion=15.16.0

--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -117,6 +117,13 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
+    override fun getLaunchDeepLink(promise: Promise) {
+        promise.resolve(scope) {
+            this.proxy.getLaunchDeepLink()
+        }
+    }
+
+    @ReactMethod
     override fun airshipListenerAdded(eventName: String?) {
         if (eventName == null) {
             return

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -193,6 +193,12 @@ public extension AirshipReactNative {
         return Airship.isFlying
     }
 
+    @objc
+    @MainActor
+    func getLaunchDeepLink() async -> String? {
+        return await AirshipProxy.shared.getLaunchDeepLink()
+    }
+
 }
 
 // Channel

--- a/ios/RNAirship.mm
+++ b/ios/RNAirship.mm
@@ -92,6 +92,14 @@ RCT_REMAP_METHOD(isFlying,
     resolve(@([AirshipReactNative.shared isFlying]));
 }
 
+RCT_REMAP_METHOD(getLaunchDeepLink,
+                 getLaunchDeepLink:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+    [AirshipReactNative.shared getLaunchDeepLinkWithCompletionHandler:^(NSString *result) {
+        resolve(result);
+    }];
+}
+
 RCT_REMAP_METHOD(channelAddTag,
                  channelAddTag:(NSString *)tag
                  resolve:(RCTPromiseResolveBlock)resolve

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
   
-  s.dependency "AirshipFrameworkProxy", "15.14.0"
+  s.dependency "AirshipFrameworkProxy", "15.16.0"
 end

--- a/src/AirshipRoot.ts
+++ b/src/AirshipRoot.ts
@@ -84,6 +84,11 @@ export class AirshipRoot {
    * Returns the deep link that launched the app from a notification tap, or
    * null if the app was not launched by a notification with a deep link.
    *
+   * Only reflects a cold app launch or background-to-foreground launch
+   * triggered by the tap. A notification tapped while the app is already in
+   * the foreground will not be returned here; use the `EventType.DeepLink`
+   * listener below for that case.
+   *
    * One-shot: the value is consumed on read. Intended to be wired as React
    * Navigation's `linking.getInitialURL`, with an `EventType.DeepLink`
    * listener as `linking.subscribe`:

--- a/src/AirshipRoot.ts
+++ b/src/AirshipRoot.ts
@@ -81,6 +81,34 @@ export class AirshipRoot {
   }
 
   /**
+   * Returns the deep link that launched the app from a notification tap, or
+   * null if the app was not launched by a notification with a deep link.
+   *
+   * One-shot: the value is consumed on read. Intended to be wired as React
+   * Navigation's `linking.getInitialURL`, with an `EventType.DeepLink`
+   * listener as `linking.subscribe`:
+   *
+   * ```ts
+   * const linking = {
+   *   prefixes: ['myapp://'],
+   *   getInitialURL: () => Airship.getLaunchDeepLink(),
+   *   subscribe: (listener) => {
+   *     const subscription = Airship.addListener(
+   *       EventType.DeepLink,
+   *       (event) => listener(event.deepLink)
+   *     );
+   *     return () => subscription.remove();
+   *   },
+   * };
+   * ```
+   *
+   * @returns A promise with the launching deep link, or null.
+   */
+  public getLaunchDeepLink(): Promise<string | null | undefined> {
+    return this.module.getLaunchDeepLink();
+  }
+
+  /**
    * Adds a listener.
    * @param eventType The listener type.
    * @param listener The listener.

--- a/src/NativeRNAirship.ts
+++ b/src/NativeRNAirship.ts
@@ -4,6 +4,7 @@ export interface Spec extends TurboModule {
   // Airship
   takeOff(config: Object): Promise<boolean>;
   isFlying(): Promise<boolean>;
+  getLaunchDeepLink(): Promise<string | null | undefined>;
   airshipListenerAdded(eventName: string): void;
   takePendingEvents(
     eventName: string,


### PR DESCRIPTION
### What do these changes do?
Adds `Airship.getLaunchDeepLink()`, a one-shot getter for the deep link that launched the app from a notification tap, wired for React Navigation's `linking.getInitialURL`.

### Why are these changes necessary?
Declarative-linking apps miss Airship deep links on cold start because the event fires after the navigation container mounts.

### How did you verify these changes?
Typecheck and lint match main's baseline; builds and on-device cold start runs need the proxy release with `AirshipProxy.getLaunchDeepLink()` first.