### PR TITLE
Add Swift Package Manager support for React Native 0.87

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,93 @@
+// swift-tools-version: 6.0
+
+// Copyright Airship and Contributors
+
+// Swift Package Manager manifest for React Native's SwiftPM integration
+// (React Native 0.87+, `npx react-native spm`). CocoaPods remains the default
+// integration and continues to use react-native-airship.podspec.
+//
+// React Native's autolinker references this package through a
+// `build/generated/autolinking/libs/ReactNativeAirship` symlink inside the
+// app's `ios/` directory, so the relative package paths below are resolved
+// from that location rather than from node_modules.
+
+import PackageDescription
+
+let reactHeaders: [Target.Dependency] = [
+    .product(name: "ReactHeaders", package: "ReactNative"),
+    .product(name: "ReactNativeHeaders", package: "ReactNative"),
+    .product(name: "ReactNativeDependenciesHeaders", package: "ReactNative"),
+    .product(name: "ReactAppHeaders", package: "React-GeneratedCode"),
+]
+
+let package = Package(
+    name: "ReactNativeAirship",
+    platforms: [.iOS(.v16)],
+    products: [
+        .library(
+            name: "ReactNativeAirship",
+            targets: ["ReactNativeAirshipBridge", "react_native_airship", "ReactNativeAirshipObjC"]
+        ),
+    ],
+    dependencies: [
+        .package(name: "ReactNative", path: "../../../../xcframeworks"),
+        .package(name: "React-GeneratedCode", path: "../../../ios"),
+        .package(url: "https://github.com/urbanairship/airship-mobile-framework-proxy.git", exact: "15.16.0"),
+    ],
+    targets: [
+        // SwiftPM cannot compile Swift and Objective-C++ in one target, and
+        // Xcode does not expose a Swift target's generated header to sibling
+        // Objective-C targets. The Objective-C++ React Native glue therefore
+        // talks to the Swift implementation through the protocols in the
+        // bridge target, which both sides depend on.
+        .target(
+            name: "ReactNativeAirshipBridge",
+            path: "ios/Bridge",
+            publicHeadersPath: "."
+        ),
+        .target(
+            name: "react_native_airship",
+            dependencies: reactHeaders + [
+                "ReactNativeAirshipBridge",
+                .product(name: "AirshipFrameworkProxy", package: "airship-mobile-framework-proxy"),
+            ],
+            path: "ios",
+            sources: [
+                "AirshipEmbeddedViewWrapper.swift",
+                "AirshipPluginLoader.swift",
+                "AirshipReactNative.swift",
+                "MessageWebViewWrapper.swift",
+                "ProxyDataMigrator.swift",
+            ]
+        ),
+        .target(
+            name: "ReactNativeAirshipObjC",
+            dependencies: reactHeaders + ["ReactNativeAirshipBridge"],
+            path: "ios",
+            sources: [
+                "RNAirship.mm",
+                "RNAirshipBootloader.m",
+                "RNAirshipEmbeddedView.mm",
+                "RNAirshipEmbeddedViewViewManager.mm",
+                "RNAirshipMessageView.mm",
+                "RNAirshipMessageViewManager.mm",
+            ],
+            publicHeadersPath: ".",
+            cSettings: [
+                .define("RCT_NEW_ARCH_ENABLED", to: "1"),
+            ],
+            cxxSettings: [
+                .define("RCT_NEW_ARCH_ENABLED", to: "1"),
+                // Match the prebuilt React.framework's config-gated C++ ABI.
+                .define("DEBUG", .when(configuration: .debug)),
+                .define("NDEBUG", .when(configuration: .release)),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation"),
+                .linkedFramework("UIKit"),
+                .linkedFramework("WebKit"),
+            ]
+        ),
+    ],
+    cxxLanguageStandard: .cxx20
+)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ Then, add the plugin to your `app.json`:
   ]
   ```
 
+### Swift Package Manager (iOS, experimental)
+
+React Native 0.87 adds an experimental, opt-in Swift Package Manager integration as an alternative to CocoaPods. This package ships a `Package.swift`, so it is picked up automatically once your app is set up for SwiftPM:
+
+```bash
+cd ios
+npx react-native spm
+```
+
+CocoaPods remains the default integration. React Native's SwiftPM support is still marked experimental, and its generated autolinking package currently declares an iOS 15 minimum, which prevents packages that require iOS 16 (including this one) from resolving until React Native raises that floor.
+
 ### Initialization
 
 Initialize Airship in your `App.tsx`:

--- a/ios/AirshipEmbeddedViewWrapper.swift
+++ b/ios/AirshipEmbeddedViewWrapper.swift
@@ -1,12 +1,20 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
+#if canImport(AirshipKit)
 import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+import AirshipAutomation
+#endif
 import AirshipFrameworkProxy
 import SwiftUI
+#if canImport(ReactNativeAirshipBridge)
+import ReactNativeAirshipBridge
+#endif
 
 @objc(RNAirshipEmbeddedViewWrapper)
-public final class AirshipEmbeddedViewWrapper: UIView {
+public final class AirshipEmbeddedViewWrapper: UIView, RNAirshipEmbeddedViewBridge {
     private let viewModel = ReactAirshipEmbeddedView.ViewModel()
     @objc
     public let viewController: UIViewController

--- a/ios/AirshipPluginLoader.swift
+++ b/ios/AirshipPluginLoader.swift
@@ -1,7 +1,12 @@
 /* Copyright Airship and Contributors */
 
+import Foundation
 import AirshipFrameworkProxy
+#if canImport(AirshipKit)
 import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
 
 @objc(AirshipPluginLoader)
 @MainActor

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -1,12 +1,19 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
+#if canImport(AirshipKit)
 import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
 import AirshipFrameworkProxy
 import React
+#if canImport(ReactNativeAirshipBridge)
+import ReactNativeAirshipBridge
+#endif
 
-@objc
-public final class AirshipReactNative: NSObject, Sendable {
+@objc(AirshipReactNative)
+public final class AirshipReactNative: NSObject, Sendable, @preconcurrency RNAirshipBridge {
 
     @objc
     public static let pendingEventsEventName = "com.airship.pending_events"
@@ -612,7 +619,7 @@ public extension AirshipReactNative {
     }
 
   @objc
-  func preferenceCenterGetConfig(preferenceCenterId: String) async throws -> AnyHashable? {
+  func preferenceCenterGetConfig(preferenceCenterId: String) async throws -> Any? {
         return try await AirshipProxy.shared.preferenceCenter.getPreferenceCenterConfig(
             preferenceCenterID: preferenceCenterId
         ).unWrap()

--- a/ios/Bridge/RNAirshipBridge.h
+++ b/ios/Bridge/RNAirshipBridge.h
@@ -1,0 +1,148 @@
+/* Copyright Airship and Contributors */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Objective-C interface to the Swift side of the module.
+ *
+ * The Objective-C++ React Native glue (TurboModule and Fabric views) cannot
+ * import the Swift-generated header when built with Swift Package Manager, so
+ * the Swift classes conform to these protocols and are resolved by name at
+ * runtime. The Swift compiler enforces that every requirement is implemented.
+ */
+@protocol RNAirshipBridge <NSObject>
+
+@property (nonatomic, class, readonly, copy) NSString * _Nonnull pendingEventsEventName;
+@property (nonatomic, class, readonly, copy) NSString * _Nonnull overridePresentationOptionsEventName;
+@property (nonatomic, class, readonly, copy) NSString * _Nonnull pendingEmbeddedUpdated;
+
+@property (nonatomic) BOOL overridePresentationOptionsEnabled;
+- (void)setNotifier:(void (^ _Nullable)(NSString * _Nonnull, NSDictionary<NSString *, id> * _Nonnull))notifier NS_SWIFT_NAME(setNotifier(_:));
+- (void)presentationOptionOverridesResultWithRequestID:(NSString * _Nonnull)requestID presentationOptions:(NSArray<NSString *> * _Nullable)presentationOptions NS_SWIFT_NAME(presentationOptionOverridesResult(requestID:presentationOptions:));
+- (void)onListenerAddedWithEventName:(NSString * _Nonnull)eventName NS_SWIFT_NAME(onListenerAdded(eventName:));
+- (void)takePendingEventsWithEventName:(NSString * _Nonnull)eventName completionHandler:(void (^ _Nonnull)(NSArray * _Nonnull))completionHandler NS_SWIFT_NAME(takePendingEvents(eventName:)) NS_SWIFT_ASYNC_NAME(takePendingEvents(eventName:));
+- (void)attemptTakeOff NS_SWIFT_NAME(attemptTakeOff());
+- (void)actionsRunWithAction:(NSDictionary<NSString *, id> * _Nonnull)action completionHandler:(void (^ _Nonnull)(id _Nullable_result, NSError * _Nullable))completionHandler NS_SWIFT_NAME(actionsRun(action:)) NS_SWIFT_ASYNC_NAME(actionsRun(action:));
+- (BOOL)localeSetLocaleOverrideWithLocaleIdentifier:(NSString * _Nullable)localeIdentifier error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(localeSetLocaleOverride(localeIdentifier:));
+- (BOOL)localeClearLocaleOverrideAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(localeClearLocaleOverride());
+- (NSString * _Nullable)localeGetLocaleAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(localeGetLocale());
+- (BOOL)preferenceCenterDisplayWithPreferenceCenterId:(NSString * _Nonnull)preferenceCenterId error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(preferenceCenterDisplay(preferenceCenterId:));
+- (void)preferenceCenterGetConfigWithPreferenceCenterId:(NSString * _Nonnull)preferenceCenterId completionHandler:(void (^ _Nonnull)(id _Nullable_result, NSError * _Nullable))completionHandler NS_SWIFT_NAME(preferenceCenterGetConfig(preferenceCenterId:)) NS_SWIFT_ASYNC_NAME(preferenceCenterGetConfig(preferenceCenterId:));
+- (void)preferenceCenterAutoLaunchDefaultPreferenceCenterWithPreferenceCenterId:(NSString * _Nonnull)preferenceCenterId autoLaunch:(BOOL)autoLaunch NS_SWIFT_NAME(preferenceCenterAutoLaunchDefaultPreferenceCenter(preferenceCenterId:autoLaunch:));
+- (NSNumber * _Nullable)takeOffWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(takeOff(json:));
+- (BOOL)isFlying NS_SWIFT_NAME(isFlying());
+- (void)getLaunchDeepLinkWithCompletionHandler:(void (^ _Nonnull)(NSString * _Nullable))completionHandler NS_SWIFT_NAME(getLaunchDeepLink()) NS_SWIFT_ASYNC_NAME(getLaunchDeepLink());
+- (BOOL)analyticsTrackScreen:(NSString * _Nullable)screen error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(analyticsTrackScreen(_:));
+- (BOOL)analyticsAssociateIdentifier:(NSString * _Nullable)identifier key:(NSString * _Nonnull)key error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(analyticsAssociateIdentifier(_:key:));
+- (BOOL)addCustomEvent:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(addCustomEvent(_:));
+- (NSString * _Nullable)analyticsGetSessionIdAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(analyticsGetSessionId());
+- (void)featureFlagManagerFlagWithFlagName:(NSString * _Nonnull)flagName useResultCache:(BOOL)useResultCache completionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(featureFlagManagerFlag(flagName:useResultCache:)) NS_SWIFT_ASYNC_NAME(featureFlagManagerFlag(flagName:useResultCache:));
+- (BOOL)featureFlagManagerTrackInteractedWithFlag:(id _Nonnull)flag error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(featureFlagManagerTrackInteracted(flag:));
+- (void)featureFlagManagerResultCacheGetFlagWithName:(NSString * _Nonnull)name completionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(featureFlagManagerResultCacheGetFlag(name:)) NS_SWIFT_ASYNC_NAME(featureFlagManagerResultCacheGetFlag(name:));
+- (void)featureFlagManagerResultCacheSetFlagWithFlag:(id _Nonnull)flag ttl:(NSNumber * _Nonnull)ttl completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(featureFlagManagerResultCacheSetFlag(flag:ttl:)) NS_SWIFT_ASYNC_NAME(featureFlagManagerResultCacheSetFlag(flag:ttl:));
+- (void)featureFlagManagerResultCacheRemoveFlagWithName:(NSString * _Nonnull)name completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(featureFlagManagerResultCacheRemoveFlag(name:)) NS_SWIFT_ASYNC_NAME(featureFlagManagerResultCacheRemoveFlag(name:));
+- (NSNumber * _Nullable)inAppIsPausedAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(inAppIsPaused());
+- (BOOL)inAppSetPaused:(BOOL)paused error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(inAppSetPaused(_:));
+- (BOOL)inAppSetDisplayIntervalWithMilliseconds:(double)milliseconds error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(inAppSetDisplayInterval(milliseconds:));
+- (NSNumber * _Nullable)inAppGetDisplayIntervalAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(inAppGetDisplayInterval());
+- (void)inAppResendPendingEmbeddedEvent NS_SWIFT_NAME(inAppResendPendingEmbeddedEvent());
+- (void)liveActivityListWithOptions:(id _Nonnull)options completionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(liveActivityList(options:)) NS_SWIFT_ASYNC_NAME(liveActivityList(options:));
+- (void)liveActivityListAllWithCompletionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(liveActivityListAll()) NS_SWIFT_ASYNC_NAME(liveActivityListAll());
+- (void)liveActivityStartWithOptions:(id _Nonnull)options completionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(liveActivityStart(options:)) NS_SWIFT_ASYNC_NAME(liveActivityStart(options:));
+- (void)liveActivityUpdateWithOptions:(id _Nonnull)options completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(liveActivityUpdate(options:)) NS_SWIFT_ASYNC_NAME(liveActivityUpdate(options:));
+- (void)liveActivityEndWithOptions:(id _Nonnull)options completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(liveActivityEnd(options:)) NS_SWIFT_ASYNC_NAME(liveActivityEnd(options:));
+- (BOOL)privacyManagerSetEnabledFeaturesWithFeatures:(NSArray<NSString *> * _Nonnull)features error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(privacyManagerSetEnabledFeatures(features:));
+- (NSArray<NSString *> * _Nullable)privacyManagerGetEnabledFeaturesAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(privacyManagerGetEnabledFeatures());
+- (BOOL)privacyManagerEnableFeatureWithFeatures:(NSArray<NSString *> * _Nonnull)features error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(privacyManagerEnableFeature(features:));
+- (BOOL)privacyManagerDisableFeatureWithFeatures:(NSArray<NSString *> * _Nonnull)features error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(privacyManagerDisableFeature(features:));
+- (NSNumber * _Nullable)privacyManagerIsFeatureEnabledWithFeatures:(NSArray<NSString *> * _Nonnull)features error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(privacyManagerIsFeatureEnabled(features:));
+- (BOOL)contactIdentify:(NSString * _Nullable)namedUser error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactIdentify(_:));
+- (BOOL)contactResetAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactReset());
+- (BOOL)contactRegisterSms:(NSString * _Nonnull)msisdn options:(id _Nonnull)options error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactRegisterSms(_:options:));
+- (BOOL)contactRegisterEmail:(NSString * _Nonnull)address options:(id _Nonnull)options error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactRegisterEmail(_:options:));
+- (BOOL)contactNotifyRemoteLoginAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactNotifyRemoteLogin());
+- (void)contactGetNamedUserIdOrEmtpyWithCompletionHandler:(void (^ _Nonnull)(NSString * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(contactGetNamedUserIdOrEmtpy()) NS_SWIFT_ASYNC_NAME(contactGetNamedUserIdOrEmtpy());
+- (void)contactGetSubscriptionListsWithCompletionHandler:(void (^ _Nonnull)(NSDictionary<NSString *, NSArray<NSString *> *> * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(contactGetSubscriptionLists()) NS_SWIFT_ASYNC_NAME(contactGetSubscriptionLists());
+- (BOOL)contactEditTagGroupsWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactEditTagGroups(json:));
+- (BOOL)contactEditAttributesWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactEditAttributes(json:));
+- (BOOL)contactEditSubscriptionListsWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(contactEditSubscriptionLists(json:));
+- (void)messageCenterGetUnreadCountWithCompletionHandler:(void (^ _Nonnull)(double, NSError * _Nullable))completionHandler NS_SWIFT_NAME(messageCenterGetUnreadCount()) NS_SWIFT_ASYNC_NAME(messageCenterGetUnreadCount());
+- (void)messageCenterGetMessagesWithCompletionHandler:(void (^ _Nonnull)(id _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(messageCenterGetMessages()) NS_SWIFT_ASYNC_NAME(messageCenterGetMessages());
+- (void)messageCenterMarkMessageReadWithMessageId:(NSString * _Nonnull)messageId completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(messageCenterMarkMessageRead(messageId:)) NS_SWIFT_ASYNC_NAME(messageCenterMarkMessageRead(messageId:));
+- (void)messageCenterDeleteMessageWithMessageId:(NSString * _Nonnull)messageId completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(messageCenterDeleteMessage(messageId:)) NS_SWIFT_ASYNC_NAME(messageCenterDeleteMessage(messageId:));
+- (BOOL)messageCenterDismissAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(messageCenterDismiss());
+- (BOOL)messageCenterDisplayWithMessageId:(NSString * _Nullable)messageId error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(messageCenterDisplay(messageId:));
+- (BOOL)messageCenterShowMessageViewWithMessageId:(NSString * _Nonnull)messageId error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(messageCenterShowMessageView(messageId:));
+- (BOOL)messageCenterShowMessageCenterWithMessageId:(NSString * _Nullable)messageId error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(messageCenterShowMessageCenter(messageId:));
+- (void)messageCenterRefreshWithCompletionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(messageCenterRefresh()) NS_SWIFT_ASYNC_NAME(messageCenterRefresh());
+- (void)messageCenterSetAutoLaunchDefaultMessageCenterWithAutoLaunch:(BOOL)autoLaunch NS_SWIFT_NAME(messageCenterSetAutoLaunchDefaultMessageCenter(autoLaunch:));
+- (BOOL)channelAddTag:(NSString * _Nonnull)tag error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelAddTag(_:));
+- (BOOL)channelRemoveTag:(NSString * _Nonnull)tag error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelRemoveTag(_:));
+- (BOOL)channelEditTagsWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelEditTags(json:));
+- (BOOL)channelEnableChannelCreationAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelEnableChannelCreation());
+- (NSArray<NSString *> * _Nullable)channelGetTagsAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelGetTags());
+- (void)channelGetSubscriptionListsWithCompletionHandler:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(channelGetSubscriptionLists()) NS_SWIFT_ASYNC_NAME(channelGetSubscriptionLists());
+- (NSString * _Nullable)channelGetChannelIdOrEmptyAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelGetChannelIdOrEmpty());
+- (void)channelWaitForChannelIdWithCompletionHandler:(void (^ _Nonnull)(NSString * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(channelWaitForChannelId()) NS_SWIFT_ASYNC_NAME(channelWaitForChannelId());
+- (BOOL)channelEditTagGroupsWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelEditTagGroups(json:));
+- (BOOL)channelEditAttributesWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelEditAttributes(json:));
+- (BOOL)channelEditSubscriptionListsWithJson:(id _Nonnull)json error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(channelEditSubscriptionLists(json:));
+- (BOOL)pushSetUserNotificationsEnabled:(BOOL)enabled error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushSetUserNotificationsEnabled(_:));
+- (NSNumber * _Nullable)pushIsUserNotificationsEnabledAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushIsUserNotificationsEnabled());
+- (void)pushEnableUserNotificationsWithOptions:(id _Nullable)options completionHandler:(void (^ _Nonnull)(BOOL, NSError * _Nullable))completionHandler NS_SWIFT_NAME(pushEnableUserNotifications(options:)) NS_SWIFT_ASYNC_NAME(pushEnableUserNotifications(options:));
+- (NSString * _Nullable)pushGetRegistrationTokenOrEmptyAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushGetRegistrationTokenOrEmpty());
+- (BOOL)pushSetNotificationOptionsWithNames:(NSArray<NSString *> * _Nonnull)names error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushSetNotificationOptions(names:));
+- (BOOL)pushSetForegroundPresentationOptionsWithNames:(NSArray<NSString *> * _Nonnull)names error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushSetForegroundPresentationOptions(names:));
+- (void)pushGetNotificationStatusWithCompletionHandler:(void (^ _Nonnull)(NSDictionary<NSString *, id> * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(pushGetNotificationStatus()) NS_SWIFT_ASYNC_NAME(pushGetNotificationStatus());
+- (BOOL)pushSetAutobadgeEnabled:(BOOL)enabled error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushSetAutobadgeEnabled(_:));
+- (NSNumber * _Nullable)pushIsAutobadgeEnabledAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushIsAutobadgeEnabled());
+- (void)pushSetBadgeNumber:(double)badgeNumber completionHandler:(void (^ _Nonnull)(NSError * _Nullable))completionHandler NS_SWIFT_NAME(pushSetBadgeNumber(_:)) NS_SWIFT_ASYNC_NAME(pushSetBadgeNumber(_:));
+- (NSNumber * _Nullable)pushGetBadgeNumberAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushGetBadgeNumber());
+- (NSString * _Nullable)pushGetAuthorizedNotificationStatusAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushGetAuthorizedNotificationStatus());
+- (NSArray<NSString *> * _Nullable)pushGetAuthorizedNotificationSettingsAndReturnError:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(pushGetAuthorizedNotificationSettings());
+- (void)pushClearNotifications NS_SWIFT_NAME(pushClearNotifications());
+- (void)pushClearNotification:(NSString * _Nonnull)identifier NS_SWIFT_NAME(pushClearNotification(_:));
+- (void)pushGetActiveNotificationsWithCompletionHandler:(void (^ _Nonnull)(NSArray<NSDictionary<NSString *, id> *> * _Nullable, NSError * _Nullable))completionHandler NS_SWIFT_NAME(pushGetActiveNotifications()) NS_SWIFT_ASYNC_NAME(pushGetActiveNotifications());
+
+@end
+
+NS_SWIFT_UI_ACTOR
+@protocol RNAirshipMessageWebViewWrapperDelegate <NSObject>
+- (void)onMessageBodyLoadFailedWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onMessageBodyLoadFailed(messageID:));
+- (void)onMessageGoneWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onMessageGone(messageID:));
+- (void)onMessageLoadFailedWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onMessageLoadFailed(messageID:));
+- (void)onLoadStartedWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onLoadStarted(messageID:));
+- (void)onLoadFinishedWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onLoadFinished(messageID:));
+- (void)onCloseWithMessageID:(NSString *)messageID NS_SWIFT_NAME(onClose(messageID:));
+@end
+
+NS_SWIFT_UI_ACTOR
+@protocol RNAirshipMessageWebViewBridge <NSObject>
+@property (nonatomic, weak, nullable) id<RNAirshipMessageWebViewWrapperDelegate> delegate;
+- (void)loadMessageWithMessageID:(nullable NSString *)messageID NS_SWIFT_NAME(loadMessage(messageID:));
+@end
+
+NS_SWIFT_UI_ACTOR
+@protocol RNAirshipEmbeddedViewBridge <NSObject>
+- (void)setConfig:(nullable NSString *)json;
+@end
+
+/// The Swift `AirshipReactNative` class.
+FOUNDATION_EXPORT Class<RNAirshipBridge> RNAirshipBridgeClass(void);
+
+/// The shared `AirshipReactNative` instance.
+FOUNDATION_EXPORT id<RNAirshipBridge> RNAirshipBridgeShared(void);
+
+/// The Swift `RNAirshipMessageWebViewWrapper` view class.
+FOUNDATION_EXPORT Class RNAirshipMessageWebViewBridgeClass(void);
+
+/// The Swift `RNAirshipEmbeddedViewWrapper` view class.
+FOUNDATION_EXPORT Class RNAirshipEmbeddedViewBridgeClass(void);
+
+/// Disables automatic takeOff by the Swift `AirshipPluginLoader`.
+FOUNDATION_EXPORT void RNAirshipBridgeDisablePluginLoader(void);
+
+NS_ASSUME_NONNULL_END

--- a/ios/Bridge/RNAirshipBridge.m
+++ b/ios/Bridge/RNAirshipBridge.m
@@ -1,0 +1,35 @@
+/* Copyright Airship and Contributors */
+
+#import "RNAirshipBridge.h"
+
+// Class members that are looked up at runtime rather than through the
+// RNAirshipBridge conformance. Declared privately so the calls type-check.
+@protocol RNAirshipBridgeProvider
+@property (nonatomic, class, readonly) id<RNAirshipBridge> shared;
+@end
+
+@protocol RNAirshipPluginLoaderProvider
+@property (nonatomic, class) BOOL disabled;
+@end
+
+Class<RNAirshipBridge> RNAirshipBridgeClass(void) {
+    return NSClassFromString(@"AirshipReactNative");
+}
+
+id<RNAirshipBridge> RNAirshipBridgeShared(void) {
+    Class<RNAirshipBridgeProvider> cls = NSClassFromString(@"AirshipReactNative");
+    return [cls shared];
+}
+
+Class RNAirshipMessageWebViewBridgeClass(void) {
+    return NSClassFromString(@"RNAirshipMessageWebViewWrapper");
+}
+
+Class RNAirshipEmbeddedViewBridgeClass(void) {
+    return NSClassFromString(@"RNAirshipEmbeddedViewWrapper");
+}
+
+void RNAirshipBridgeDisablePluginLoader(void) {
+    Class<RNAirshipPluginLoaderProvider> cls = NSClassFromString(@"AirshipPluginLoader");
+    [cls setDisabled:YES];
+}

--- a/ios/MessageWebViewWrapper.swift
+++ b/ios/MessageWebViewWrapper.swift
@@ -1,18 +1,16 @@
 /* Copyright Airship and Contributors */
 
 import Foundation
+#if canImport(AirshipKit)
 import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+import AirshipMessageCenter
+#endif
 import SwiftUI
-
-@objc(RNAirshipMessageWebViewWrapperDelegate)
-public protocol MessageWebViewWrapperDelegate: AnyObject {
-    func onMessageBodyLoadFailed(messageID: String)
-    func onMessageGone(messageID: String)
-    func onMessageLoadFailed(messageID: String)
-    func onLoadStarted(messageID: String)
-    func onLoadFinished(messageID: String)
-    func onClose(messageID: String)
-}
+#if canImport(ReactNativeAirshipBridge)
+import ReactNativeAirshipBridge
+#endif
 
 @MainActor
 private class MessageState: ObservableObject {
@@ -42,9 +40,9 @@ private struct MessageContainerView: View {
 
 @objc(RNAirshipMessageWebViewWrapper)
 @MainActor
-public final class MessageWebViewWrapper: UIView {
+public final class MessageWebViewWrapper: UIView, RNAirshipMessageWebViewBridge {
 
-    @objc public weak var delegate: MessageWebViewWrapperDelegate?
+    @objc public weak var delegate: RNAirshipMessageWebViewWrapperDelegate?
 
     private let state: MessageState
     private let hostingController: UIHostingController<MessageContainerView>

--- a/ios/ProxyDataMigrator.swift
+++ b/ios/ProxyDataMigrator.swift
@@ -3,7 +3,11 @@
 import Foundation
 import AirshipFrameworkProxy
 import UserNotifications
+#if canImport(AirshipKit)
 import AirshipKit
+#elseif canImport(AirshipCore)
+import AirshipCore
+#endif
 
 struct ProxyDataMigrator {
 

--- a/ios/RNAirship.mm
+++ b/ios/RNAirship.mm
@@ -2,11 +2,7 @@
 
 #import "RNAirship.h"
 
-#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
-#import <react_native_airship/react_native_airship-Swift.h>
-#else
-#import "react_native_airship-Swift.h"
-#endif
+#import "RNAirshipBridge.h"
 
 @implementation RNAirship
 + (NSString *)moduleName
@@ -16,28 +12,28 @@
 
 - (NSArray<NSString *> *)supportedEvents {
     return @[
-        AirshipReactNative.pendingEventsEventName,
-        AirshipReactNative.overridePresentationOptionsEventName,
-        AirshipReactNative.pendingEmbeddedUpdated
+        [RNAirshipBridgeClass() pendingEventsEventName],
+        [RNAirshipBridgeClass() overridePresentationOptionsEventName],
+        [RNAirshipBridgeClass() pendingEmbeddedUpdated]
     ];
 }
 
 -(void)startObserving {
     __weak RNAirship *weakSelf = self;
     
-    [AirshipReactNative.shared setNotifier:^(NSString *name, NSDictionary<NSString *,id> *body) {
+    [RNAirshipBridgeShared() setNotifier:^(NSString *name, NSDictionary<NSString *,id> *body) {
         [weakSelf sendEventWithName:name body:body];
     }];
 }
 
 -(void)stopObserving {
-    [AirshipReactNative.shared setNotifier:nil];
+    [RNAirshipBridgeShared() setNotifier:nil];
 }
 
 - (void)setBridge:(RCTBridge *)bridge {
     self.reactBridge = bridge;
 
-    [AirshipReactNative.shared attemptTakeOff];
+    [RNAirshipBridgeShared() attemptTakeOff];
 }
 
 - (RCTBridge *)bridge {
@@ -61,7 +57,7 @@
 }
 
 RCT_EXPORT_METHOD(airshipListenerAdded:(NSString *)eventName) {
-    [AirshipReactNative.shared onListenerAddedWithEventName:eventName];
+    [RNAirshipBridgeShared() onListenerAddedWithEventName:eventName];
 }
 
 RCT_REMAP_METHOD(takePendingEvents,
@@ -70,7 +66,7 @@ RCT_REMAP_METHOD(takePendingEvents,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     // isHeadlessJS is always false for iOS. It's an Android only flag.
-    [AirshipReactNative.shared takePendingEventsWithEventName:eventName completionHandler:^(NSArray *result) {
+    [RNAirshipBridgeShared() takePendingEventsWithEventName:eventName completionHandler:^(NSArray *result) {
         resolve(result);
     }];
 }
@@ -80,7 +76,7 @@ RCT_REMAP_METHOD(takeOff,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared takeOffWithJson:config
+    id result = [RNAirshipBridgeShared() takeOffWithJson:config
                                                      error:&error];
     
     [self handleResult:result error:error resolve:resolve reject:reject];
@@ -89,13 +85,13 @@ RCT_REMAP_METHOD(takeOff,
 RCT_REMAP_METHOD(isFlying,
                  isFlying:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    resolve(@([AirshipReactNative.shared isFlying]));
+    resolve(@([RNAirshipBridgeShared() isFlying]));
 }
 
 RCT_REMAP_METHOD(getLaunchDeepLink,
                  getLaunchDeepLink:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared getLaunchDeepLinkWithCompletionHandler:^(NSString *result) {
+    [RNAirshipBridgeShared() getLaunchDeepLinkWithCompletionHandler:^(NSString *result) {
         resolve(result);
     }];
 }
@@ -105,7 +101,7 @@ RCT_REMAP_METHOD(channelAddTag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelAddTag:tag error:&error];
+    [RNAirshipBridgeShared() channelAddTag:tag error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -115,7 +111,7 @@ RCT_REMAP_METHOD(channelRemoveTag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelRemoveTag:tag error:&error];
+    [RNAirshipBridgeShared() channelRemoveTag:tag error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -125,7 +121,7 @@ RCT_REMAP_METHOD(channelEditTags,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelEditTagsWithJson:operations
+    [RNAirshipBridgeShared() channelEditTagsWithJson:operations
                                                       error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -135,7 +131,7 @@ RCT_REMAP_METHOD(channelEnableChannelCreation,
                  channelEnableChannelCreation:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelEnableChannelCreationAndReturnError:&error];
+    [RNAirshipBridgeShared() channelEnableChannelCreationAndReturnError:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -143,24 +139,24 @@ RCT_REMAP_METHOD(channelEnableChannelCreation,
 RCT_REMAP_METHOD(pushGetActiveNotifications,
                  pushGetActiveNotifications:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared pushGetActiveNotificationsWithCompletionHandler:^(NSArray<NSDictionary<NSString *,id> *> *result, NSError *error) {
+    [RNAirshipBridgeShared() pushGetActiveNotificationsWithCompletionHandler:^(NSArray<NSDictionary<NSString *,id> *> *result, NSError *error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
 }
 
 RCT_EXPORT_METHOD(pushClearNotifications) {
-    [AirshipReactNative.shared pushClearNotifications];
+    [RNAirshipBridgeShared() pushClearNotifications];
 }
 
 RCT_EXPORT_METHOD(pushClearNotification:(NSString *)identifier) {
-    [AirshipReactNative.shared pushClearNotification:identifier];
+    [RNAirshipBridgeShared() pushClearNotification:identifier];
 }
 
 RCT_REMAP_METHOD(pushGetNotificationStatus,
                  pushGetNotificationStatus:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared pushGetNotificationStatusWithCompletionHandler:^(id result, NSError *error) {
+    [RNAirshipBridgeShared() pushGetNotificationStatusWithCompletionHandler:^(id result, NSError *error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
 }
@@ -169,7 +165,7 @@ RCT_REMAP_METHOD(pushGetRegistrationToken,
                  pushGetRegistrationToken:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    NSString *result = [AirshipReactNative.shared pushGetRegistrationTokenOrEmptyAndReturnError:&error];
+    NSString *result = [RNAirshipBridgeShared() pushGetRegistrationTokenOrEmptyAndReturnError:&error];
 
     [self handleResult:result.length ? result : nil
                  error:error
@@ -181,7 +177,7 @@ RCT_REMAP_METHOD(pushIsUserNotificationsEnabled,
                  pushIsUserNotificationsEnabled:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared  pushIsUserNotificationsEnabledAndReturnError:&error];
+    id result = [RNAirshipBridgeShared()  pushIsUserNotificationsEnabledAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -191,7 +187,7 @@ RCT_REMAP_METHOD(pushSetUserNotificationsEnabled,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared pushSetUserNotificationsEnabled:enabled
+    [RNAirshipBridgeShared() pushSetUserNotificationsEnabled:enabled
                                                          error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -201,7 +197,7 @@ RCT_REMAP_METHOD(pushEnableUserNotifications,
                  pushEnableUserNotifications:(NSDictionary *)options
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared pushEnableUserNotificationsWithOptions:options completionHandler:^(BOOL result, NSError *error) {
+    [RNAirshipBridgeShared() pushEnableUserNotificationsWithOptions:options completionHandler:^(BOOL result, NSError *error) {
         [self handleResult:@(result)
                      error:error
                    resolve:resolve
@@ -224,7 +220,7 @@ RCT_REMAP_METHOD(pushIosGetBadgeNumber,
                  pushIosGetBadgeNumber:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared  pushGetBadgeNumberAndReturnError:&error];
+    id result = [RNAirshipBridgeShared()  pushGetBadgeNumberAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -233,7 +229,7 @@ RCT_REMAP_METHOD(pushIosIsAutobadgeEnabled,
                  pushIosIsAutobadgeEnabled:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared  pushIsAutobadgeEnabledAndReturnError:&error];
+    id result = [RNAirshipBridgeShared()  pushIsAutobadgeEnabledAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -243,7 +239,7 @@ RCT_REMAP_METHOD(pushIosSetAutobadgeEnabled,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared pushSetAutobadgeEnabled:enabled
+    [RNAirshipBridgeShared() pushSetAutobadgeEnabled:enabled
                                                  error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -253,7 +249,7 @@ RCT_REMAP_METHOD(pushIosSetBadgeNumber,
                  pushIosSetBadgeNumber:(double)badgeNumber
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared pushSetBadgeNumber:badgeNumber completionHandler:^(NSError *error) {
+    [RNAirshipBridgeShared() pushSetBadgeNumber:badgeNumber completionHandler:^(NSError *error) {
         [self handleResult:nil
                      error:error
                    resolve:resolve
@@ -266,7 +262,7 @@ RCT_REMAP_METHOD(pushIosSetForegroundPresentationOptions,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared pushSetForegroundPresentationOptionsWithNames:options
+    [RNAirshipBridgeShared() pushSetForegroundPresentationOptionsWithNames:options
                                                                        error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -277,7 +273,7 @@ RCT_REMAP_METHOD(pushIosSetNotificationOptions,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared pushSetNotificationOptionsWithNames:options
+    [RNAirshipBridgeShared() pushSetNotificationOptionsWithNames:options
                                                              error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -288,7 +284,7 @@ RCT_REMAP_METHOD(channelEditAttributes,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelEditAttributesWithJson:operations
+    [RNAirshipBridgeShared() channelEditAttributesWithJson:operations
                                                        error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -299,7 +295,7 @@ RCT_REMAP_METHOD(channelEditSubscriptionLists,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelEditSubscriptionListsWithJson:operations
+    [RNAirshipBridgeShared() channelEditSubscriptionListsWithJson:operations
                                                               error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -310,7 +306,7 @@ RCT_REMAP_METHOD(channelEditTagGroups,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared channelEditTagGroupsWithJson:operations
+    [RNAirshipBridgeShared() channelEditTagGroupsWithJson:operations
                                                       error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -321,7 +317,7 @@ RCT_REMAP_METHOD(channelGetChannelId,
                  channelGetChannelId:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    NSString *result = [AirshipReactNative.shared  channelGetChannelIdOrEmptyAndReturnError:&error];
+    NSString *result = [RNAirshipBridgeShared()  channelGetChannelIdOrEmptyAndReturnError:&error];
 
     [self handleResult:result.length ? result : nil
                  error:error
@@ -333,7 +329,7 @@ RCT_REMAP_METHOD(channelWaitForChannelId,
                  channelWaitForChannelId:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared channelWaitForChannelIdWithCompletionHandler:^(NSString *result, NSError *error) {
+    [RNAirshipBridgeShared() channelWaitForChannelIdWithCompletionHandler:^(NSString *result, NSError *error) {
         [self handleResult:result
                      error:error
                    resolve:resolve
@@ -344,7 +340,7 @@ RCT_REMAP_METHOD(channelWaitForChannelId,
 
 RCT_REMAP_METHOD(channelGetSubscriptionLists,
                  channelGetSubscriptionLists:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared channelGetSubscriptionListsWithCompletionHandler:^(NSArray<NSString *> *result, NSError *error) {
+    [RNAirshipBridgeShared() channelGetSubscriptionListsWithCompletionHandler:^(NSArray<NSString *> *result, NSError *error) {
 
         [self handleResult:result
                      error:error
@@ -357,7 +353,7 @@ RCT_REMAP_METHOD(channelGetTags,
                  channelGetTags:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared channelGetTagsAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() channelGetTagsAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -366,7 +362,7 @@ RCT_REMAP_METHOD(actionRun,
                  actionRun:(NSDictionary *)action
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared actionsRunWithAction:action
+    [RNAirshipBridgeShared() actionsRunWithAction:action
                                       completionHandler:^(id result , NSError *error) {
 
 
@@ -383,7 +379,7 @@ RCT_REMAP_METHOD(analyticsAssociateIdentifier,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared analyticsAssociateIdentifier:identifier
+    [RNAirshipBridgeShared() analyticsAssociateIdentifier:identifier
                                                         key:key
                                                       error:&error];
 
@@ -395,7 +391,7 @@ RCT_REMAP_METHOD(analyticsTrackScreen,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared analyticsTrackScreen:screen
+    [RNAirshipBridgeShared() analyticsTrackScreen:screen
                                               error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -406,7 +402,7 @@ RCT_REMAP_METHOD(addCustomEvent,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared addCustomEvent:event
+    [RNAirshipBridgeShared() addCustomEvent:event
                                         error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -416,7 +412,7 @@ RCT_REMAP_METHOD(analyticsGetSessionId,
                  analyticsGetSessionId:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    NSString *result = [AirshipReactNative.shared analyticsGetSessionIdAndReturnError:&error];
+    NSString *result = [RNAirshipBridgeShared() analyticsGetSessionIdAndReturnError:&error];
 
     [self handleResult:result
                  error:error
@@ -430,7 +426,7 @@ RCT_REMAP_METHOD(contactEditAttributes,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactEditAttributesWithJson:operations
+    [RNAirshipBridgeShared() contactEditAttributesWithJson:operations
                                                        error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -441,7 +437,7 @@ RCT_REMAP_METHOD(contactEditSubscriptionLists,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactEditSubscriptionListsWithJson:operations
+    [RNAirshipBridgeShared() contactEditSubscriptionListsWithJson:operations
                                                               error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -452,7 +448,7 @@ RCT_REMAP_METHOD(contactEditTagGroups,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactEditTagGroupsWithJson:operations
+    [RNAirshipBridgeShared() contactEditTagGroupsWithJson:operations
                                                       error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -461,7 +457,7 @@ RCT_REMAP_METHOD(contactEditTagGroups,
 RCT_REMAP_METHOD(contactGetSubscriptionLists,
                  contactGetSubscriptionLists:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared contactGetSubscriptionListsWithCompletionHandler:^(NSDictionary *result, NSError *error) {
+    [RNAirshipBridgeShared() contactGetSubscriptionListsWithCompletionHandler:^(NSDictionary *result, NSError *error) {
 
         [self handleResult:result
                      error:error
@@ -474,7 +470,7 @@ RCT_REMAP_METHOD(contactGetNamedUserId,
                  contactGetNamedUserId:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared contactGetNamedUserIdOrEmtpyWithCompletionHandler:^(NSString *result, NSError *error) {
+    [RNAirshipBridgeShared() contactGetNamedUserIdOrEmtpyWithCompletionHandler:^(NSString *result, NSError *error) {
         [self handleResult:result.length ? result : nil
                      error:error
                    resolve:resolve
@@ -487,7 +483,7 @@ RCT_REMAP_METHOD(contactIdentify,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactIdentify:namedUser
+    [RNAirshipBridgeShared() contactIdentify:namedUser
                                          error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -497,7 +493,7 @@ RCT_REMAP_METHOD(contactReset,
                  contactReset:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactResetAndReturnError:&error];
+    [RNAirshipBridgeShared() contactResetAndReturnError:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -508,7 +504,7 @@ RCT_REMAP_METHOD(contactRegisterSms,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactRegisterSms:msisdn
+    [RNAirshipBridgeShared() contactRegisterSms:msisdn
                                           options:options
                                            error:&error];
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -520,7 +516,7 @@ RCT_REMAP_METHOD(contactRegisterEmail,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactRegisterEmail:address
+    [RNAirshipBridgeShared() contactRegisterEmail:address
                                             options:options
                                              error:&error];
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -530,7 +526,7 @@ RCT_REMAP_METHOD(contactNotifyRemoteLogin,
                  contactNotifyRemoteLogin:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared contactNotifyRemoteLoginAndReturnError:&error];
+    [RNAirshipBridgeShared() contactNotifyRemoteLoginAndReturnError:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -539,7 +535,7 @@ RCT_REMAP_METHOD(inAppGetDisplayInterval,
                  inAppGetDisplayInterval:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared inAppGetDisplayIntervalAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() inAppGetDisplayIntervalAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -548,7 +544,7 @@ RCT_REMAP_METHOD(inAppIsPaused,
                  inAppIsPaused:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared inAppIsPausedAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() inAppIsPausedAndReturnError:&error];
     
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -558,7 +554,7 @@ RCT_REMAP_METHOD(inAppSetDisplayInterval,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared inAppSetDisplayIntervalWithMilliseconds:milliseconds
+    [RNAirshipBridgeShared() inAppSetDisplayIntervalWithMilliseconds:milliseconds
                                                                  error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -569,21 +565,21 @@ RCT_REMAP_METHOD(inAppSetPaused,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared inAppSetPaused:paused
+    [RNAirshipBridgeShared() inAppSetPaused:paused
                                         error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
 
 RCT_EXPORT_METHOD(inAppResendPendingEmbeddedEvent) {
-    [AirshipReactNative.shared inAppResendPendingEmbeddedEvent];
+    [RNAirshipBridgeShared() inAppResendPendingEmbeddedEvent];
 }
 
 RCT_REMAP_METHOD(localeClearLocaleOverride,
                  localeClearLocaleOverride:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared localeClearLocaleOverrideAndReturnError:&error];
+    [RNAirshipBridgeShared() localeClearLocaleOverrideAndReturnError:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -592,7 +588,7 @@ RCT_REMAP_METHOD(localeGetLocale,
                  localeGetLocale:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared localeGetLocaleAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() localeGetLocaleAndReturnError:&error];
 
     
     [self handleResult:result error:error resolve:resolve reject:reject];
@@ -603,7 +599,7 @@ RCT_REMAP_METHOD(localeSetLocaleOverride,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared localeSetLocaleOverrideWithLocaleIdentifier:localeIdentifier
+    [RNAirshipBridgeShared() localeSetLocaleOverrideWithLocaleIdentifier:localeIdentifier
                                                                      error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -613,7 +609,7 @@ RCT_REMAP_METHOD(messageCenterDeleteMessage,
                  messageCenterDeleteMessage:(NSString *)messageId
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared messageCenterDeleteMessageWithMessageId:messageId
+    [RNAirshipBridgeShared() messageCenterDeleteMessageWithMessageId:messageId
                                                      completionHandler:^(NSError * error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];
@@ -624,7 +620,7 @@ RCT_REMAP_METHOD(messageCenterDismiss,
                  reject:(RCTPromiseRejectBlock)reject) {
 
     NSError *error;
-    [AirshipReactNative.shared messageCenterDismissAndReturnError:&error];
+    [RNAirshipBridgeShared() messageCenterDismissAndReturnError:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -634,7 +630,7 @@ RCT_REMAP_METHOD(messageCenterDisplay,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared messageCenterDisplayWithMessageId:messageId
+    [RNAirshipBridgeShared() messageCenterDisplayWithMessageId:messageId
                                                            error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -645,7 +641,7 @@ RCT_REMAP_METHOD(messageCenterShowMessageCenter,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared messageCenterShowMessageCenterWithMessageId:messageId
+    [RNAirshipBridgeShared() messageCenterShowMessageCenterWithMessageId:messageId
                                                            error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -656,7 +652,7 @@ RCT_REMAP_METHOD(messageCenterShowMessageView,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared messageCenterShowMessageViewWithMessageId:messageId
+    [RNAirshipBridgeShared() messageCenterShowMessageViewWithMessageId:messageId
                                                            error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -666,7 +662,7 @@ RCT_REMAP_METHOD(messageCenterGetMessages,
                  messageCenterGetMessages:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared messageCenterGetMessagesWithCompletionHandler:^(NSArray *result, NSError *error) {
+    [RNAirshipBridgeShared() messageCenterGetMessagesWithCompletionHandler:^(NSArray *result, NSError *error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
 }
@@ -675,7 +671,7 @@ RCT_REMAP_METHOD(messageCenterGetUnreadCount,
                  messageCenterGetUnreadCount:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared messageCenterGetUnreadCountWithCompletionHandler:^(double result, NSError *error) {
+    [RNAirshipBridgeShared() messageCenterGetUnreadCountWithCompletionHandler:^(double result, NSError *error) {
         [self handleResult:@(result) error:error resolve:resolve reject:reject];
     }];
 }
@@ -684,7 +680,7 @@ RCT_REMAP_METHOD(messageCenterMarkMessageRead,
                  messageCenterMarkMessageRead:(NSString *)messageId
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared messageCenterMarkMessageReadWithMessageId:messageId
+    [RNAirshipBridgeShared() messageCenterMarkMessageReadWithMessageId:messageId
                                                        completionHandler:^(NSError * error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];
@@ -693,18 +689,18 @@ RCT_REMAP_METHOD(messageCenterMarkMessageRead,
 RCT_REMAP_METHOD(messageCenterRefresh,
                  messageCenterRefresh:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
-    [AirshipReactNative.shared messageCenterRefreshWithCompletionHandler:^(NSError *error) {
+    [RNAirshipBridgeShared() messageCenterRefreshWithCompletionHandler:^(NSError *error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];
 }
 
 RCT_EXPORT_METHOD(messageCenterSetAutoLaunchDefaultMessageCenter:(BOOL)enabled) {
-    [AirshipReactNative.shared messageCenterSetAutoLaunchDefaultMessageCenterWithAutoLaunch:enabled];
+    [RNAirshipBridgeShared() messageCenterSetAutoLaunchDefaultMessageCenterWithAutoLaunch:enabled];
 }
 
 RCT_EXPORT_METHOD(preferenceCenterAutoLaunchDefaultPreferenceCenter:(NSString *)preferenceCenterId
                   autoLaunch:(BOOL)autoLaunch) {
-    [AirshipReactNative.shared preferenceCenterAutoLaunchDefaultPreferenceCenterWithPreferenceCenterId:preferenceCenterId
+    [RNAirshipBridgeShared() preferenceCenterAutoLaunchDefaultPreferenceCenterWithPreferenceCenterId:preferenceCenterId
                                                                                             autoLaunch:autoLaunch];
 }
 
@@ -714,7 +710,7 @@ RCT_REMAP_METHOD(preferenceCenterDisplay,
                  reject:(RCTPromiseRejectBlock)reject) {
 
     NSError *error;
-    [AirshipReactNative.shared preferenceCenterDisplayWithPreferenceCenterId:preferenceCenterId
+    [RNAirshipBridgeShared() preferenceCenterDisplayWithPreferenceCenterId:preferenceCenterId
                                                                        error:&error];
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -724,7 +720,7 @@ RCT_REMAP_METHOD(preferenceCenterGetConfig,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared preferenceCenterGetConfigWithPreferenceCenterId:preferenceCenterId
+    [RNAirshipBridgeShared() preferenceCenterGetConfigWithPreferenceCenterId:preferenceCenterId
                                                            completionHandler:^(id result, NSError *error) {
         [self handleResult:result
                      error:error
@@ -738,7 +734,7 @@ RCT_REMAP_METHOD(privacyManagerDisableFeature,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared privacyManagerDisableFeatureWithFeatures:features error:&error];
+    [RNAirshipBridgeShared() privacyManagerDisableFeatureWithFeatures:features error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -748,7 +744,7 @@ RCT_REMAP_METHOD(privacyManagerEnableFeature,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared privacyManagerEnableFeatureWithFeatures:features error:&error];
+    [RNAirshipBridgeShared() privacyManagerEnableFeatureWithFeatures:features error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
@@ -757,7 +753,7 @@ RCT_REMAP_METHOD(privacyManagerGetEnabledFeatures,
                  privacyManagerGetEnabledFeatures:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared privacyManagerGetEnabledFeaturesAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() privacyManagerGetEnabledFeaturesAndReturnError:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
@@ -767,7 +763,7 @@ RCT_REMAP_METHOD(privacyManagerIsFeatureEnabled,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared privacyManagerIsFeatureEnabledWithFeatures:features
+    id result = [RNAirshipBridgeShared() privacyManagerIsFeatureEnabledWithFeatures:features
                                                                                 error:&error];
 
     [self handleResult:result error:error resolve:resolve reject:reject];
@@ -778,25 +774,25 @@ RCT_REMAP_METHOD(privacyManagerSetEnabledFeatures,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    [AirshipReactNative.shared privacyManagerSetEnabledFeaturesWithFeatures:features error:&error];
+    [RNAirshipBridgeShared() privacyManagerSetEnabledFeaturesWithFeatures:features error:&error];
 
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
 
 
 RCT_EXPORT_METHOD(pushIosIsOverridePresentationOptionsEnabled:(BOOL)enabled) {
-    AirshipReactNative.shared.overridePresentationOptionsEnabled = enabled;
+    RNAirshipBridgeShared().overridePresentationOptionsEnabled = enabled;
 }
 
 RCT_EXPORT_METHOD(pushIosOverridePresentationOptions:(NSString *)requestID options:(NSArray *)presentationOptions) {
-    [AirshipReactNative.shared presentationOptionOverridesResultWithRequestID:requestID presentationOptions:presentationOptions];
+    [RNAirshipBridgeShared() presentationOptionOverridesResultWithRequestID:requestID presentationOptions:presentationOptions];
 }
 
 RCT_REMAP_METHOD(pushIosGetAuthorizedNotificationSettings,
                  pushIosGetAuthorizedNotificationSettings:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared pushGetAuthorizedNotificationSettingsAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() pushGetAuthorizedNotificationSettingsAndReturnError:&error];
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
 
@@ -804,7 +800,7 @@ RCT_REMAP_METHOD(pushIosGetAuthorizedNotificationStatus,
                  pushIosGetAuthorizedNotificationStatus:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     NSError *error;
-    id result = [AirshipReactNative.shared pushGetAuthorizedNotificationStatusAndReturnError:&error];
+    id result = [RNAirshipBridgeShared() pushGetAuthorizedNotificationStatusAndReturnError:&error];
     [self handleResult:result error:error resolve:resolve reject:reject];
 }
 
@@ -823,7 +819,7 @@ RCT_REMAP_METHOD(featureFlagManagerTrackInteraction,
 
 
     NSError *error;
-    [AirshipReactNative.shared featureFlagManagerTrackInteractedWithFlag:flag error:&error];
+    [RNAirshipBridgeShared() featureFlagManagerTrackInteractedWithFlag:flag error:&error];
     [self handleResult:nil error:error resolve:resolve reject:reject];
 }
 
@@ -833,7 +829,7 @@ RCT_REMAP_METHOD(featureFlagManagerFlag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared featureFlagManagerFlagWithFlagName:flagName
+    [RNAirshipBridgeShared() featureFlagManagerFlagWithFlagName:flagName
                                                    useResultCache:useResultCache
                                                 completionHandler:^(id result, NSError * _Nullable error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
@@ -845,7 +841,7 @@ RCT_REMAP_METHOD(featureFlagManagerResultCacheGetFlag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared featureFlagManagerResultCacheGetFlagWithName:flagName
+    [RNAirshipBridgeShared() featureFlagManagerResultCacheGetFlagWithName:flagName
                                                 completionHandler:^(id result, NSError * _Nullable error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
@@ -857,7 +853,7 @@ RCT_REMAP_METHOD(featureFlagManagerResultCacheSetFlag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared featureFlagManagerResultCacheSetFlagWithFlag:flag
+    [RNAirshipBridgeShared() featureFlagManagerResultCacheSetFlagWithFlag:flag
                                                                 ttl:@(ttl)
                                                           completionHandler:^(NSError * _Nullable error) {
                   [self handleResult:nil error:error resolve:resolve reject:reject];
@@ -869,7 +865,7 @@ RCT_REMAP_METHOD(featureFlagManagerResultCacheRemoveFlag,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared featureFlagManagerResultCacheRemoveFlagWithName:flagName
+    [RNAirshipBridgeShared() featureFlagManagerResultCacheRemoveFlagWithName:flagName
                                                      completionHandler:^(NSError * _Nullable error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];
@@ -880,7 +876,7 @@ RCT_REMAP_METHOD(liveActivityListAll,
                  liveActivityListAll:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared liveActivityListAllWithCompletionHandler:^(id result, NSError * _Nullable error) {
+    [RNAirshipBridgeShared() liveActivityListAllWithCompletionHandler:^(id result, NSError * _Nullable error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
 }
@@ -890,7 +886,7 @@ RCT_REMAP_METHOD(liveActivityList,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared liveActivityListWithOptions:request
+    [RNAirshipBridgeShared() liveActivityListWithOptions:request
                                                 completionHandler:^(id result, NSError * _Nullable error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
@@ -901,7 +897,7 @@ RCT_REMAP_METHOD(liveActivityStart,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared liveActivityStartWithOptions:request
+    [RNAirshipBridgeShared() liveActivityStartWithOptions:request
                                            completionHandler:^(id result, NSError * _Nullable error) {
         [self handleResult:result error:error resolve:resolve reject:reject];
     }];
@@ -912,7 +908,7 @@ RCT_REMAP_METHOD(liveActivityUpdate,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared liveActivityUpdateWithOptions:request
+    [RNAirshipBridgeShared() liveActivityUpdateWithOptions:request
                                            completionHandler:^(NSError * _Nullable error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];
@@ -923,7 +919,7 @@ RCT_REMAP_METHOD(liveActivityEnd,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
 
-    [AirshipReactNative.shared liveActivityEndWithOptions:request
+    [RNAirshipBridgeShared() liveActivityEndWithOptions:request
                                         completionHandler:^(NSError * _Nullable error) {
         [self handleResult:nil error:error resolve:resolve reject:reject];
     }];

--- a/ios/RNAirshipBootloader.m
+++ b/ios/RNAirshipBootloader.m
@@ -2,17 +2,13 @@
 
 #import "RNAirshipBootloader.h"
 
-#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
-#import <react_native_airship/react_native_airship-Swift.h>
-#else
-#import "react_native_airship-Swift.h"
-#endif
+#import "RNAirshipBridge.h"
 
 @implementation RNAirshipBootloader
 
 
 + (void)disable {
-    AirshipPluginLoader.disabled = YES;
+    RNAirshipBridgeDisablePluginLoader();
 }
 @end
 

--- a/ios/RNAirshipEmbeddedView.mm
+++ b/ios/RNAirshipEmbeddedView.mm
@@ -2,11 +2,7 @@
 
 #import "RNAirshipEmbeddedView.h"
 
-#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
-#import <react_native_airship/react_native_airship-Swift.h>
-#else
-#import "react_native_airship-Swift.h"
-#endif
+#import "RNAirshipBridge.h"
 
 #import "react/renderer/components/RNAirshipSpec/ComponentDescriptors.h"
 #import "react/renderer/components/RNAirshipSpec/EventEmitters.h"
@@ -15,13 +11,13 @@
 
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 
 using namespace facebook::react;
 #endif
 
 @interface RNAirshipEmbeddedView() <RCTRNAirshipEmbeddedViewViewProtocol>
-@property (nonatomic, strong)RNAirshipEmbeddedViewWrapper *wrapper;
+@property (nonatomic, strong)UIView<RNAirshipEmbeddedViewBridge> *wrapper;
 @end
 
 @implementation RNAirshipEmbeddedView
@@ -59,7 +55,7 @@ using namespace facebook::react;
 - (instancetype) init {
     self = [self initWithFrame:CGRectZero];
     if (self) {
-        self.wrapper = [[RNAirshipEmbeddedViewWrapper alloc] initWithFrame:self.bounds];
+        self.wrapper = [[RNAirshipEmbeddedViewBridgeClass() alloc] initWithFrame:self.bounds];
         [self addSubview:self.wrapper];
     }
     return self;

--- a/ios/RNAirshipMessageView.mm
+++ b/ios/RNAirshipMessageView.mm
@@ -2,11 +2,7 @@
 
 #import "RNAirshipMessageView.h"
 
-#if __has_include(<react_native_airship/react_native_airship-Swift.h>)
-#import <react_native_airship/react_native_airship-Swift.h>
-#else
-#import "react_native_airship-Swift.h"
-#endif
+#import "RNAirshipBridge.h"
 
 #import "react/renderer/components/RNAirshipSpec/ComponentDescriptors.h"
 #import "react/renderer/components/RNAirshipSpec/EventEmitters.h"
@@ -14,12 +10,12 @@
 #import "react/renderer/components/RNAirshipSpec/RCTComponentViewHelpers.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 using namespace facebook::react;
 #endif
 
 @interface RNAirshipMessageView() <RNAirshipMessageWebViewWrapperDelegate, RCTRNAirshipMessageViewViewProtocol>
-@property (nonatomic, strong)RNAirshipMessageWebViewWrapper *wrapper;
+@property (nonatomic, strong)UIView<RNAirshipMessageWebViewBridge> *wrapper;
 @end
 
 NSString *const RNAirshipMessageViewErrorMessageNotAvailable = @"MESSAGE_NOT_AVAILABLE";
@@ -66,7 +62,7 @@ NSString *const RNAirshipMessageViewErrorKey = @"error";
 - (instancetype) init {
     self = [self initWithFrame:CGRectZero];
     if (self) {
-        self.wrapper = [[RNAirshipMessageWebViewWrapper alloc] initWithFrame:self.bounds];
+        self.wrapper = [[RNAirshipMessageWebViewBridgeClass() alloc] initWithFrame:self.bounds];
         self.wrapper.delegate = self;
         [self addSubview:self.wrapper];
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "Package.swift",
     "react-native.config.js",
     "!ios/build",
     "!android/build",

--- a/react-native-airship.podspec
+++ b/react-native-airship.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift,cpp}"
   s.exclude_files = "ios/generated/**/*"
-  s.private_header_files = "ios/**/*.h"
+  s.private_header_files = "ios/*.h"
   s.swift_version = "6.0"
 
   install_modules_dependencies(s)


### PR DESCRIPTION
### What do these changes do?
Adds a `Package.swift` for React Native 0.87's SwiftPM integration and moves the ObjC++ to Swift calls behind protocols in a small bridge target, since SwiftPM can't build the Swift and ObjC++ sources as one module. CocoaPods keeps working unchanged.

### Why are these changes necessary?
RN 0.87 ships an opt-in SwiftPM path and libraries have to bring their own manifest.

### How did you verify these changes?
Built a fresh RN 0.87.1 app with `npx react-native spm` against the packed tarball, and built and ran the CocoaPods example on the RN 0.86 simulator.

### Anything else a reviewer should know?
RN's generated autolinking package hardcodes an iOS 15 floor, and SwiftPM refuses to depend on a product that needs iOS 16, so SwiftPM apps won't resolve this package until React Native raises that (it's a one-liner in `scripts/spm/generate-spm-autolinking.js`). The SwiftPM verification above was done with that floor patched locally. CocoaPods users are unaffected.
