### PR TITLE
[MOBILE-5857] Add feature flag status, waitRefresh, and status event

### DIFF
--- a/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/AirshipModule.kt
@@ -764,6 +764,20 @@ class AirshipModule internal constructor(val context: ReactApplicationContext) :
     }
 
     @ReactMethod
+    override fun featureFlagManagerStatus(promise: Promise) {
+        promise.resolve(scope) {
+            proxy.featureFlagManager.status
+        }
+    }
+
+    @ReactMethod
+    override fun featureFlagManagerWaitRefresh(maxTimeMillis: Double?, promise: Promise) {
+        promise.resolve(scope) {
+            proxy.featureFlagManager.waitRefresh(maxTimeMillis?.toLong())
+        }
+    }
+
+    @ReactMethod
     override fun liveActivityListAll(promise: Promise) {
         promise.resolve(scope) {
             throw IllegalStateException("Not supported on Android")

--- a/android/src/main/java/com/urbanairship/reactnative/Utils.kt
+++ b/android/src/main/java/com/urbanairship/reactnative/Utils.kt
@@ -27,7 +27,8 @@ object Utils {
                 EventType.BACKGROUND_PUSH_RECEIVED
         ),
         "com.airship.notification_status_changed" to listOf(EventType.NOTIFICATION_STATUS_CHANGED),
-        "com.airship.pending_embedded_updated" to listOf(EventType.PENDING_EMBEDDED_UPDATED)
+        "com.airship.pending_embedded_updated" to listOf(EventType.PENDING_EMBEDDED_UPDATED),
+        "com.airship.feature_flag_status_changed" to listOf(EventType.FEATURE_FLAG_STATUS_CHANGED)
     )
 
     fun convertArray(array: ReadableArray?): JsonValue {

--- a/ios/AirshipReactNative.swift
+++ b/ios/AirshipReactNative.swift
@@ -698,6 +698,18 @@ public extension AirshipReactNative {
     func featureFlagManagerResultCacheRemoveFlag(name: String) async throws {
         try await AirshipProxy.shared.featureFlagManager.resultCache.removeCachedFlag(name: name)
     }
+
+    @objc
+    func featureFlagManagerStatus() async throws -> String {
+        return try await AirshipProxy.shared.featureFlagManager.status.rawValue
+    }
+
+    @objc
+    func featureFlagManagerWaitRefresh(maxTimeMillis: NSNumber?) async throws {
+        try await AirshipProxy.shared.featureFlagManager.waitRefresh(
+            maxTime: maxTimeMillis.map { $0.doubleValue / 1000.0 }
+        )
+    }
 }
 
 
@@ -810,7 +822,8 @@ extension AirshipProxyEventType {
         "com.airship.notification_status_changed": .notificationStatusChanged,
         "com.airship.authorized_notification_settings_changed": .authorizedNotificationSettingsChanged,
         "com.airship.pending_embedded_updated": .pendingEmbeddedUpdated,
-        "com.airship.live_activities_updated": .liveActivitiesUpdated
+        "com.airship.live_activities_updated": .liveActivitiesUpdated,
+        "com.airship.feature_flag_status_changed": .featureFlagStatusChanged
     ]
 
     public static func fromReactName(_ name: String) throws -> AirshipProxyEventType {

--- a/ios/RNAirship.mm
+++ b/ios/RNAirship.mm
@@ -875,6 +875,26 @@ RCT_REMAP_METHOD(featureFlagManagerResultCacheRemoveFlag,
     }];
 }
 
+RCT_REMAP_METHOD(featureFlagManagerStatus,
+                 featureFlagManagerStatus:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+
+    [AirshipReactNative.shared featureFlagManagerStatusWithCompletionHandler:^(NSString * _Nullable result, NSError * _Nullable error) {
+        [self handleResult:result error:error resolve:resolve reject:reject];
+    }];
+}
+
+RCT_REMAP_METHOD(featureFlagManagerWaitRefresh,
+                 featureFlagManagerWaitRefresh:(NSNumber *)maxTimeMillis
+                 resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+
+    [AirshipReactNative.shared featureFlagManagerWaitRefreshWithMaxTimeMillis:maxTimeMillis
+                                                            completionHandler:^(NSError * _Nullable error) {
+        [self handleResult:nil error:error resolve:resolve reject:reject];
+    }];
+}
+
 
 RCT_REMAP_METHOD(liveActivityListAll,
                  liveActivityListAll:(RCTPromiseResolveBlock)resolve

--- a/src/AirshipFeatureFlagManager.ts
+++ b/src/AirshipFeatureFlagManager.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag } from './types';
+import { FeatureFlag, FeatureFlagUpdateStatus } from './types';
 
 /**
  * Airship feature flag manager.
@@ -35,6 +35,26 @@ export class AirshipFeatureFlagManager {
    */
   public trackInteraction(flag: FeatureFlag): Promise<void> {
     return this.module.featureFlagManagerTrackInteraction(flag);
+  }
+
+  /**
+   * Gets the current feature flag rule update status.
+   * @return {Promise<FeatureFlagUpdateStatus>} A promise resolving to the status.
+   */
+  public status(): Promise<FeatureFlagUpdateStatus> {
+    return this.module.featureFlagManagerStatus();
+  }
+
+  /**
+   * Waits for the feature flag rules to refresh. Returns immediately if the
+   * last refresh already succeeded. Use `EventType.FeatureFlagStatusChanged`
+   * to be notified if the refresh completes after the wait times out.
+   * @param {number} maxTimeMillis Optional max time in milliseconds to wait.
+   * If not provided, waits until the refresh succeeds.
+   * @return {Promise<Void>} A promise with an empty result.
+   */
+  public waitRefresh(maxTimeMillis?: number): Promise<void> {
+    return this.module.featureFlagManagerWaitRefresh(maxTimeMillis);
   }
 }
 

--- a/src/NativeRNAirship.ts
+++ b/src/NativeRNAirship.ts
@@ -121,6 +121,8 @@ export interface Spec extends TurboModule {
   featureFlagManagerResultCacheGetFlag(flagName: string): Promise<Object>;
   featureFlagManagerResultCacheSetFlag(flag: Object, ttl: number): Promise<void>;
   featureFlagManagerResultCacheRemoveFlag(flagName: string): Promise<void>;
+  featureFlagManagerStatus(): Promise<string>;
+  featureFlagManagerWaitRefresh(maxTimeMillis?: number): Promise<void>;
 
   // Live Activity
   liveActivityListAll(): Promise<Object>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,25 @@ export interface PushNotificationStatusChangedEvent {
 }
 
 /**
+ * Feature flag rule update status.
+ */
+export enum FeatureFlagUpdateStatus {
+  UpToDate = 'up_to_date',
+  Stale = 'stale',
+  OutOfDate = 'out_of_date',
+}
+
+/**
+ * Event fired when the feature flag rule update status changes.
+ */
+export interface FeatureFlagStatusChangedEvent {
+  /**
+   * The feature flag rule update status.
+   */
+  status: FeatureFlagUpdateStatus;
+}
+
+/**
  * Event fired when the Message Center is updated.
  */
 export interface MessageCenterUpdatedEvent {
@@ -229,6 +248,7 @@ export enum EventType {
   PushTokenReceived = 'com.airship.push_token_received',
   IOSAuthorizedNotificationSettingsChanged = 'com.airship.authorized_notification_settings_changed',
   IOSLiveActivitiesUpdated = 'com.airship.live_activities_updated',
+  FeatureFlagStatusChanged = 'com.airship.feature_flag_status_changed',
 }
 
 export interface EventTypeMap {
@@ -243,6 +263,7 @@ export interface EventTypeMap {
   [EventType.DisplayPreferenceCenter]: DisplayPreferenceCenterEvent;
   [EventType.PushTokenReceived]: PushTokenReceivedEvent;
   [EventType.IOSLiveActivitiesUpdated]: LiveActivitiesUpdatedEvent;
+  [EventType.FeatureFlagStatusChanged]: FeatureFlagStatusChangedEvent;
 }
 
 /**


### PR DESCRIPTION
### What do these changes do?
Adds featureFlags.status(), waitRefresh(), and a FeatureFlagStatusChanged event across the JS and native layers.

### Why are these changes necessary?
Lets apps wait for fresh flag rules at launch and correct themselves when rules update mid-session (MOBILE-5857).

### How did you verify these changes?
Typecheck and bob build pass, the Android library compiled against a locally published proxy/SDK chain, and the iOS example app built with the local proxy pod.

### Anything else a reviewer should know?
Red until the proxy releases with the new APIs, then the podspec and airshipProxyVersion get bumped here.